### PR TITLE
ci: リリースパイプライン(GoReleaser)を再有効化

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,38 +10,35 @@ permissions:
   packages: write
 
 jobs:
-  # goreleaser:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - name: Checkout
-  #     uses: actions/checkout@v4
-  #     with:
-  #       fetch-depth: 0
-
-  #   - name: Set up Go
-  #     uses: actions/setup-go@v5
-  #     with:
-  #       go-version: '1.24.0'
-
-  #   - name: Login to GitHub Container Registry
-  #     uses: docker/login-action@v3
-  #     with:
-  #       registry: ghcr.io
-  #       username: ${{ github.actor }}
-  #       password: ${{ secrets.GITHUB_TOKEN }}
-
-  #   - name: Run GoReleaser
-  #     uses: goreleaser/goreleaser-action@v6
-  #     with:
-  #       distribution: goreleaser
-  #       version: latest
-  #       args: release --clean
-  #     env:
-  #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  
-  # Placeholder job to keep workflow valid
-  placeholder:
+  goreleaser:
     runs-on: ubuntu-latest
     steps:
-    - name: Placeholder
-      run: echo "GoReleaser is temporarily disabled"
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24.x'
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: '~> v2'
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # PAT required to push to the external Homebrew tap / Scoop bucket repos.
+          # The default GITHUB_TOKEN cannot write to other repositories.
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+          SCOOP_BUCKET_GITHUB_TOKEN: ${{ secrets.SCOOP_BUCKET_GITHUB_TOKEN }}


### PR DESCRIPTION
## 概要

一時的に無効化されていたリリースパイプライン（GoReleaser）を再有効化します。

`v*` タグの push をトリガーに、GoReleaser がクロスプラットフォームバイナリ・アーカイブ・チェックサム・Docker/GHCR イメージ・deb/rpm/apk パッケージ・Homebrew tap・Scoop bucket を生成/公開します。

## 変更内容

`.github/workflows/release.yml` を全面的に書き換えました。

- コメントアウトされていた `goreleaser` ジョブを復活させ、`echo "GoReleaser is temporarily disabled"` だけを実行していたプレースホルダージョブを削除。
- `actions/checkout@v4` を `fetch-depth: 0`（タグ・履歴全体取得。changelog 生成に必須）で実行。
- `actions/setup-go@v5` を `go-version: '1.24.x'`（go.mod の `go 1.24` / `toolchain go1.24.3` に対応）で設定。
- GHCR への Docker イメージ push 用に `docker/login-action@v3` でログイン。
- `goreleaser/goreleaser-action@v6` を `args: release --clean` で実行。`.goreleaser.yml` が `version: 2` のため action 側も `version: '~> v2'` に固定。
- 既存の権限設定（`permissions: contents: write` / `packages: write`）を維持。
- 環境変数を以下の通り注入:
  - `GITHUB_TOKEN`: GitHub Release 作成と GHCR push 用（自動付与のデフォルトトークン）。
  - `HOMEBREW_TAP_GITHUB_TOKEN`: 外部リポジトリ `kimkiyong/homebrew-tap` への push 用 PAT。
  - `SCOOP_BUCKET_GITHUB_TOKEN`: 外部リポジトリ `kimkiyong/scoop-bucket` への push 用 PAT。

`.goreleaser.yml` は変更していません。

## メンテナが事前に満たすべき前提条件（重要）

このタグを push しても、以下を満たさないと **リリースは失敗します**。

### 1. 必須のリポジトリ Secret

| Secret 名 | 用途 | 未設定時の挙動 |
|---|---|---|
| `GITHUB_TOKEN` | GitHub Release 作成 / GHCR への Docker push | Actions が自動付与するため設定不要 |
| `HOMEBREW_TAP_GITHUB_TOKEN` | `kimkiyong/homebrew-tap` への formula push（`.goreleaser.yml` `brews[].repository.token` が参照） | 安定版タグで brew セクションが **ハードフェイル** |
| `SCOOP_BUCKET_GITHUB_TOKEN` | `kimkiyong/scoop-bucket` への manifest push（`.goreleaser.yml` `scoops[].repository.token` が参照） | 安定版タグで scoop セクションが **ハードフェイル** |

`HOMEBREW_TAP_GITHUB_TOKEN` / `SCOOP_BUCKET_GITHUB_TOKEN` は **デフォルトの `GITHUB_TOKEN` では代用不可** です（別リポジトリへの書き込みには PAT が必要）。対象 tap/bucket リポジトリへの `contents: write` 権限を持つ Personal Access Token（classic なら `repo`、fine-grained なら対象リポジトリの Contents: Read and write）を設定してください。

なお `.goreleaser.yml` の brew/scoop には `skip_upload: auto` が設定されており、プレリリース（`prerelease: auto` 判定）やスナップショットでは push がスキップされます。したがってトークン未設定でも `v1.0.0-rc1` のようなプレリリースタグなら通る可能性がありますが、**安定版タグ（例: `v1.0.0`）では brew/scoop の push が実行され、トークンが無い/空だと認証エラーで失敗します。**

### 2. 外部リポジトリの存在

- `kimkiyong/homebrew-tap`
- `kimkiyong/scoop-bucket`

これらが存在しない場合、brew/scoop の publish は失敗します。

### 3. owner 不一致の確認（要対応の可能性）

`.goreleaser.yml` 内のリリース先 owner が **`kimkiyong`** になっていますが、本リポジトリの実体は **`kyong0612/youtube-mcp`** です。

- `release.github.owner: kimkiyong` → GitHub Release を `kimkiyong/youtube-mcp` に作成しようとするため、本リポジトリ（`kyong0612`）でのリリースは失敗または意図しない場所に作成される恐れがあります。
- `brews[].repository.owner: kimkiyong` / `scoops[].repository.owner: kimkiyong` も同様に `kimkiyong` を指しています。

本 PR では `.goreleaser.yml` を変更しない方針のため未修正です。実際の所有者に合わせて `.goreleaser.yml` の owner（および tap/bucket リポジトリ）を見直すか、`kimkiyong` 側にリリースする運用なら対象リポジトリと PAT を用意してください。

## 対応案（brew/scoop のトークンが用意できない場合）

トークン/外部リポジトリを用意しない場合は、`.goreleaser.yml` の `brews:` / `scoops:` セクションを削除（またはコメントアウト）することで、バイナリ・アーカイブ・Docker・nfpm パッケージのリリースのみを成功させられます。本 PR では安全側に倒し、セクションの削除は行っていません。メンテナの判断で「Secret を追加する」か「該当セクションを外す」かを選択してください。

## テスト状況

- `.github/workflows/release.yml` / `.goreleaser.yml` の YAML パースを確認（`yq` および ruby の YAML loader でOK。当環境では PyYAML/pip が利用不可のため等価ツールで検証）。
- `go build ./...` 成功。
- **GoReleaser 自体は未実行**（リリースは行っていません）。パイプラインの再有効化のみで、実際の挙動はタグを push するまで未検証です。
