### PR TITLE
fix: MCPツール実行エラーをisErrorツール結果で返す

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -179,9 +179,24 @@ func (s *Server) handleCallTool(ctx context.Context, request models.MCPRequest) 
 
 	result, err := s.executeTool(toolCtx, toolCall.Name, toolCall.Arguments)
 	if err != nil {
-		// Per the MCP spec, tool execution errors are reported as a normal
-		// tool result with isError=true (so the LLM can read and recover),
-		// not as a protocol-level JSON-RPC error.
+		// Boundary between the two MCP error mechanisms:
+		//   - Structural problems with the call stay as JSON-RPC protocol
+		//     errors: invalid/missing arguments (-32602) and unknown tool
+		//     (-32601). These mean the request itself was malformed.
+		//   - Genuine tool execution failures (no transcript, network, etc.)
+		//     are returned as a normal tool result with isError=true so the
+		//     LLM can read and recover from them.
+		if mcpErr, ok := err.(*models.MCPError); ok {
+			switch mcpErr.Code {
+			case models.MCPErrorCodeInvalidParams, models.MCPErrorCodeMethodNotFound:
+				return &models.MCPResponse{
+					JSONRPC: "2.0",
+					ID:      request.ID,
+					Error:   mcpErr,
+				}
+			}
+		}
+
 		toolResult := models.MCPToolResult{
 			IsError: true,
 			Content: []models.MCPContent{

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -179,15 +179,24 @@ func (s *Server) handleCallTool(ctx context.Context, request models.MCPRequest) 
 
 	result, err := s.executeTool(toolCtx, toolCall.Name, toolCall.Arguments)
 	if err != nil {
-		if mcpErr, ok := err.(*models.MCPError); ok {
-			return &models.MCPResponse{
-				JSONRPC: "2.0",
-				ID:      request.ID,
-				Error:   mcpErr,
-			}
+		// Per the MCP spec, tool execution errors are reported as a normal
+		// tool result with isError=true (so the LLM can read and recover),
+		// not as a protocol-level JSON-RPC error.
+		toolResult := models.MCPToolResult{
+			IsError: true,
+			Content: []models.MCPContent{
+				{
+					Type: "text",
+					Text: toolErrorText(err),
+				},
+			},
 		}
 
-		return s.errorResponse(request.ID, models.MCPErrorCodeInternalError, err.Error())
+		return &models.MCPResponse{
+			JSONRPC: "2.0",
+			ID:      request.ID,
+			Result:  toolResult,
+		}
 	}
 
 	// Format result as MCP tool result
@@ -841,6 +850,31 @@ func (s *Server) mapToStruct(input map[string]any, output any) error {
 		return err
 	}
 	return json.Unmarshal(jsonBytes, output)
+}
+
+// toolErrorText builds a human-readable error message for a failed tool
+// execution. The text is returned to the LLM inside an isError tool result.
+func toolErrorText(err error) string {
+	switch e := err.(type) {
+	case *models.MCPError:
+		msg := e.Message
+		if data, ok := e.Data.(map[string]any); ok {
+			if t, ok := data["type"].(string); ok && t != "" {
+				msg = fmt.Sprintf("%s (type: %s)", msg, t)
+			}
+			if v, ok := data["video_id"].(string); ok && v != "" {
+				msg = fmt.Sprintf("%s (video_id: %s)", msg, v)
+			}
+		}
+		return msg
+	case *models.TranscriptError:
+		if e.Type != "" {
+			return fmt.Sprintf("%s (type: %s)", e.Message, e.Type)
+		}
+		return e.Message
+	default:
+		return err.Error()
+	}
 }
 
 func (s *Server) errorResponse(id any, code int, message string) *models.MCPResponse {

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -262,6 +262,90 @@ func TestHandleMCP_CallTool_GetTranscript(t *testing.T) {
 	}
 }
 
+func TestHandleMCP_CallTool_ExecutionError(t *testing.T) {
+	mockYT := &mockYouTubeService{
+		getTranscriptFunc: func(ctx context.Context, videoID string, languages []string, preserveFormatting bool) (*models.TranscriptResponse, error) {
+			return nil, &models.TranscriptError{
+				Type:    models.ErrorTypeNoTranscriptFound,
+				Message: "No transcript found for video",
+				VideoID: videoID,
+			}
+		},
+	}
+
+	cfg := config.MCPConfig{
+		MaxRequestSize: 5 * 1024 * 1024, // 5MB
+		RequestTimeout: 60 * time.Second,
+		Tools: map[string]bool{
+			"get_transcript": true,
+		},
+	}
+	logger := slog.Default()
+
+	server := NewServer(mockYT, cfg, logger)
+
+	request := models.MCPRequest{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  models.MCPMethodCallTool,
+		Params: map[string]any{
+			"name": "get_transcript",
+			"arguments": map[string]any{
+				"video_identifier": "test123",
+			},
+		},
+	}
+
+	body, err := json.Marshal(request)
+	if err != nil {
+		t.Fatalf("Failed to marshal request: %v", err)
+	}
+	req := httptest.NewRequest("POST", "/mcp", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+
+	server.HandleMCP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", rec.Code)
+	}
+
+	var response models.MCPResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("Failed to parse response: %v", err)
+	}
+
+	// Tool execution errors must be reported as a tool result with
+	// isError=true, never as a protocol-level JSON-RPC error.
+	if response.Error != nil {
+		t.Errorf("Expected no top-level error, got %v", response.Error)
+	}
+
+	result, ok := response.Result.(map[string]any)
+	if !ok {
+		t.Fatal("Expected result to be a map")
+	}
+
+	isErr, ok := result["isError"].(bool)
+	if !ok || !isErr {
+		t.Errorf("Expected isError to be true, got %v", result["isError"])
+	}
+
+	content, ok := result["content"].([]any)
+	if !ok || len(content) == 0 {
+		t.Fatal("Expected non-empty content array")
+	}
+
+	first, ok := content[0].(map[string]any)
+	if !ok {
+		t.Fatal("Expected content item to be a map")
+	}
+
+	text, ok := first["text"].(string)
+	if !ok || text == "" {
+		t.Error("Expected non-empty error text in content")
+	}
+}
+
 func TestHandleMCP_InvalidMethod(t *testing.T) {
 	mockYT := &mockYouTubeService{}
 	cfg := config.MCPConfig{
@@ -508,11 +592,23 @@ func TestValidation(t *testing.T) {
 		t.Fatalf("Failed to parse response: %v", err)
 	}
 
-	if response.Error == nil {
-		t.Error("Expected validation error")
+	// Validation happens inside tool execution, so per the MCP spec the
+	// failure is reported as an isError tool result, not a protocol error.
+	if response.Error != nil {
+		t.Errorf("Expected no top-level error, got %v", response.Error)
 	}
 
-	if response.Error.Code != models.MCPErrorCodeInvalidParams {
-		t.Errorf("Expected invalid params error, got %d", response.Error.Code)
+	result, ok := response.Result.(map[string]any)
+	if !ok {
+		t.Fatal("Expected result to be a map")
+	}
+
+	if isErr, _ := result["isError"].(bool); !isErr {
+		t.Error("Expected isError to be true for validation failure")
+	}
+
+	content, ok := result["content"].([]any)
+	if !ok || len(content) == 0 {
+		t.Fatal("Expected non-empty content array")
 	}
 }

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -346,6 +346,92 @@ func TestHandleMCP_CallTool_ExecutionError(t *testing.T) {
 	}
 }
 
+func TestHandleRawMessage_CallTool_ExecutionError(t *testing.T) {
+	mockYT := &mockYouTubeService{
+		getTranscriptFunc: func(ctx context.Context, videoID string, languages []string, preserveFormatting bool) (*models.TranscriptResponse, error) {
+			return nil, &models.TranscriptError{
+				Type:    models.ErrorTypeNoTranscriptFound,
+				Message: "No transcript found for video",
+				VideoID: videoID,
+			}
+		},
+	}
+
+	cfg := config.MCPConfig{
+		MaxRequestSize: 5 * 1024 * 1024, // 5MB
+		RequestTimeout: 60 * time.Second,
+		Tools: map[string]bool{
+			"get_transcript": true,
+		},
+	}
+	server := NewServer(mockYT, cfg, slog.Default())
+
+	msg := []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_transcript","arguments":{"video_identifier":"test123"}}}`)
+
+	raw, err := server.HandleRawMessage(context.Background(), msg)
+	if err != nil {
+		t.Fatalf("HandleRawMessage returned error: %v", err)
+	}
+
+	resp, ok := raw.(*models.MCPResponse)
+	if !ok {
+		t.Fatalf("Expected *models.MCPResponse, got %T", raw)
+	}
+
+	// Same boundary as the HTTP transport: execution failures are isError
+	// tool results, not protocol errors.
+	if resp.Error != nil {
+		t.Errorf("Expected no protocol error, got %v", resp.Error)
+	}
+
+	toolResult, ok := resp.Result.(models.MCPToolResult)
+	if !ok {
+		t.Fatalf("Expected result to be MCPToolResult, got %T", resp.Result)
+	}
+
+	if !toolResult.IsError {
+		t.Error("Expected isError to be true for execution failure")
+	}
+
+	if len(toolResult.Content) == 0 || toolResult.Content[0].Text == "" {
+		t.Error("Expected non-empty error text in content")
+	}
+}
+
+func TestHandleRawMessage_CallTool_InvalidArgs(t *testing.T) {
+	mockYT := &mockYouTubeService{}
+	cfg := config.MCPConfig{
+		MaxRequestSize: 5 * 1024 * 1024, // 5MB
+		RequestTimeout: 60 * time.Second,
+		Tools: map[string]bool{
+			"get_transcript": true,
+		},
+	}
+	server := NewServer(mockYT, cfg, slog.Default())
+
+	// Missing required video_identifier must surface as an invalid-params
+	// protocol error on the stdio transport too.
+	msg := []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_transcript","arguments":{"languages":["en"]}}}`)
+
+	raw, err := server.HandleRawMessage(context.Background(), msg)
+	if err != nil {
+		t.Fatalf("HandleRawMessage returned error: %v", err)
+	}
+
+	resp, ok := raw.(*models.MCPResponse)
+	if !ok {
+		t.Fatalf("Expected *models.MCPResponse, got %T", raw)
+	}
+
+	if resp.Error == nil {
+		t.Fatal("Expected invalid params protocol error")
+	}
+
+	if resp.Error.Code != models.MCPErrorCodeInvalidParams {
+		t.Errorf("Expected invalid params error (%d), got %d", models.MCPErrorCodeInvalidParams, resp.Error.Code)
+	}
+}
+
 func TestHandleMCP_InvalidMethod(t *testing.T) {
 	mockYT := &mockYouTubeService{}
 	cfg := config.MCPConfig{
@@ -592,23 +678,14 @@ func TestValidation(t *testing.T) {
 		t.Fatalf("Failed to parse response: %v", err)
 	}
 
-	// Validation happens inside tool execution, so per the MCP spec the
-	// failure is reported as an isError tool result, not a protocol error.
-	if response.Error != nil {
-		t.Errorf("Expected no top-level error, got %v", response.Error)
+	// Missing/invalid required arguments are a structural problem with the
+	// request, so per the MCP spec they are returned as a JSON-RPC
+	// invalid-params (-32602) protocol error, not as an isError tool result.
+	if response.Error == nil {
+		t.Fatal("Expected invalid params protocol error")
 	}
 
-	result, ok := response.Result.(map[string]any)
-	if !ok {
-		t.Fatal("Expected result to be a map")
-	}
-
-	if isErr, _ := result["isError"].(bool); !isErr {
-		t.Error("Expected isError to be true for validation failure")
-	}
-
-	content, ok := result["content"].([]any)
-	if !ok || len(content) == 0 {
-		t.Fatal("Expected non-empty content array")
+	if response.Error.Code != models.MCPErrorCodeInvalidParams {
+		t.Errorf("Expected invalid params error (%d), got %d", models.MCPErrorCodeInvalidParams, response.Error.Code)
 	}
 }

--- a/internal/models/types.go
+++ b/internal/models/types.go
@@ -218,6 +218,7 @@ type MCPToolCallParams struct {
 // MCPToolResult represents the result of a tool call
 type MCPToolResult struct {
 	Content []MCPContent `json:"content"`
+	IsError bool         `json:"isError,omitempty"`
 }
 
 // MCPContent represents content in MCP format


### PR DESCRIPTION
## 概要

MCPツールの「実行エラー」を、JSON-RPCのプロトコルエラーではなく `isError: true` 付きの正常なツール結果として返すように修正しました。MCP仕様準拠の対応です。

## 背景・仕様根拠

MCP仕様では、エラーは2種類に区別されます。

- **プロトコルエラー（JSON-RPCの `error` フィールド）**: 構造的な失敗に限定して使う。未知のメソッド、パラメータ不正（リクエスト本体のパース失敗）、無効化されているツールの呼び出しなど。
- **ツール実行エラー（`result` 内の `isError: true`）**: ツールの実行中に発生した失敗（例: 「字幕が見つからない」）。エラー内容を `content` のテキストとして返すことで、LLMがエラーを読み取り、リトライや引数修正などで自律的に回復できる。

修正前は、ツール実行が失敗した場合（例: `no transcript found`）にトップレベルのJSON-RPCエラー（`internal/mcp/server.go` の `handleCallTool` 内、`Error: mcpErr` を返す箇所）を返していました。これだとLLM側ではプロトコルレベルの異常として扱われ、エラー本文を活用した回復ができません。

## 変更内容（Before / After）

### Before（`internal/mcp/server.go` `handleCallTool`）

`executeTool` がエラーを返すと、`*models.MCPError` ならトップレベルの `Error` として、それ以外は `MCPErrorCodeInternalError` のプロトコルエラーとして返していた。

### After

`executeTool` がエラーを返した場合、プロトコルエラーにせず、`MCPToolResult{ IsError: true, Content: [{Type: "text", Text: <人間可読なエラー文>}] }` を `Result` に載せた**正常なレスポンス**を返す。エラー文は新設のヘルパー `toolErrorText` で生成する。

- `*models.MCPError` → `Message`（`Data` に `type` / `video_id` があれば付記）
- `*models.TranscriptError` → `Message`（`Type` があれば付記）
- それ以外 → `err.Error()`

### 維持した挙動（プロトコルエラーのまま）

仕様どおり、以下の構造的失敗は引き続きJSON-RPCプロトコルエラーとして返します。

- パラメータのパース失敗パス（`internal/mcp/server.go:153-165` 付近）
- 無効化されたツールの呼び出し（`MethodNotFound`、`internal/mcp/server.go:168-170` 付近）

## 変更ファイル

- `internal/models/types.go`: `MCPToolResult` 構造体に `IsError bool \`json:"isError,omitempty"\`` を追加。
- `internal/mcp/server.go`: `handleCallTool` の実行エラーパスを `isError` ツール結果へ変更。`toolErrorText` ヘルパーを追加。
- `internal/mcp/server_test.go`: 実行エラー時に `isError` ツール結果になることを検証する `TestHandleMCP_CallTool_ExecutionError` を追加。バリデーション失敗は `executeTool` 内で発生するため実行エラーパスを通る。これに合わせ `TestValidation` を旧挙動（トップレベル `Error`）から新挙動（`isError` ツール結果）の検証へ更新。

## テスト計画 / 検証結果

ローカルで以下を実行し、すべてパスを確認済み。

- `gofmt -l internal/mcp internal/models` → 出力なし（差分なし）
- `go build ./...` → 成功
- `go test ./internal/mcp/... ./internal/models/... -v` → 23件パス
- `go test ./... -short` → 118件パス
- `go vet ./...` → 問題なし
