### PR TITLE
refactor: 取得をkkdai優先にして信頼性を向上(独自スクレイパはフォールバック)

### DIFF
--- a/internal/youtube/composite_fetcher_test.go
+++ b/internal/youtube/composite_fetcher_test.go
@@ -84,6 +84,20 @@ func TestCompositeFetcher_FallbackBehavior(t *testing.T) {
 	assert.Len(t, languages.Languages, 1)
 }
 
+func TestNewEnhancedService_FetcherOrder(t *testing.T) {
+	// The enhanced service must try the maintained kkdai library before
+	// falling back to the custom HTML/regex scraper. Guard the order so a
+	// future refactor does not silently regress reliability.
+	svc := &Service{logger: setupTestLogger()}
+	enhanced := NewEnhancedService(svc)
+
+	fetchers := enhanced.compositeFetcher.fetchers
+	if assert.Len(t, fetchers, 2) {
+		assert.IsType(t, &KkdaiFetcher{}, fetchers[0], "first fetcher should be KkdaiFetcher")
+		assert.IsType(t, &DefaultFetcher{}, fetchers[1], "second fetcher should be DefaultFetcher")
+	}
+}
+
 func TestCompositeFetcher_AllFail(t *testing.T) {
 	logger := setupTestLogger()
 

--- a/internal/youtube/default_fetcher.go
+++ b/internal/youtube/default_fetcher.go
@@ -43,11 +43,19 @@ func NewEnhancedService(service *Service) *EnhancedService {
 	defaultFetcher := NewDefaultFetcher(service)
 	kkdaiFetcher := NewKkdaiFetcher()
 
-	// Create composite fetcher with fallback order
+	// Create composite fetcher with fallback order.
+	//
+	// kkdai/youtube is tried first because it is an actively maintained,
+	// widely-used library that tracks YouTube's player API and is more robust
+	// against markup changes. Our custom scraper depends on a fragile regex
+	// (`var ytInitialPlayerResponse = ({.+?});` in service.go) and YouTube's
+	// frequently-changing HTML, so it is kept only as a fallback for cases the
+	// library cannot handle (e.g. richer metadata such as view/like/comment
+	// counts and channel ID, or manual/generated transcript type detection).
 	compositeFetcher := NewCompositeFetcher(
 		service.logger,
-		defaultFetcher, // Try our implementation first
-		kkdaiFetcher,   // Fall back to kkdai library
+		kkdaiFetcher,   // Try the maintained kkdai library first
+		defaultFetcher, // Fall back to our custom HTML/regex scraper
 	)
 
 	return &EnhancedService{


### PR DESCRIPTION
## 概要

トランスクリプト取得の試行順序を入れ替え、メンテナンスされている `kkdai/youtube` ライブラリを **最優先** にし、独自のHTML/正規表現スクレイパを **フォールバック** に降格しました。信頼性向上を目的とした、順序変更・コメント・テスト追加のみのサージカルな変更です。独自スクレイパは削除していません。

## 変更前後

`internal/youtube/default_fetcher.go` の `NewEnhancedService` における `CompositeFetcher` の登録順:

- 変更前: `defaultFetcher`（独自スクレイパ） → `kkdaiFetcher`
- 変更後: `kkdaiFetcher` → `defaultFetcher`（独自スクレイパ）

`CompositeFetcher` は登録順に各フェッチャーを試行し、最初に成功したものを返します（`internal/youtube/composite_fetcher.go`）。したがって順序がそのまま「どちらの実装を主に使うか」を決めます。

## 理由（独自スクレイパの脆さの根拠）

独自スクレイパはYouTubeのページHTMLから初期データを取り出すために、以下の固定的な正規表現に依存しています:

- `internal/youtube/service.go:509`
  ```go
  playerResponseRegex := regexp.MustCompile(`var ytInitialPlayerResponse = ({.+?});`)
  ```

この正規表現はYouTube側のマークアップ（埋め込みJSONの変数宣言の書式）に強く結合しており、YouTubeが頻繁に行うHTML変更でマッチしなくなると `failed to extract player response`（`service.go:512`）で取得失敗します。一方 `kkdai/youtube` はアクティブにメンテナンスされ広く利用されているライブラリで、YouTubeのplayer APIの変化に追従しており、相対的に堅牢です。そのため通常経路を堅牢な側に寄せます。

## 挙動・メタデータのトレードオフ（重要 / 要レビュー判断）

これは単なる内部整理ではなく **挙動の変化** です。取得成功時に主に使われる経路がkkdai側に変わるため、返却される `TranscriptResponse` の内容が変わり得ます。レビュー時に許容可否をご判断ください。

kkdai経路（`internal/youtube/kkdai_fetcher.go`）の特性:

- `Metadata.Source` は常に `"kkdai/youtube"`
- `TranscriptType` は常に `auto`（`kkdai_fetcher.go:101`）。独自経路のように字幕種別（auto / generated / manual）を区別しない（独自経路は `service.go:853` の `getTranscriptType` で判定）
- メタデータのサブセットが独自経路より狭い。具体的には以下を **埋めない**:
  - `ViewCount` / `LikeCount` / `CommentCount`（独自経路は `service.go:205-207` で設定）
  - `ChannelID`（独自経路は `service.go:202` で設定）
  - 一方で kkdai経路は `Title` / `Description` / `ChannelName`(Author) / `PublishedAt` などは設定する

これらのリッチなメタデータや字幕種別の区別が必要なケースでは、kkdaiが失敗した場合のフォールバックとして独自スクレイパが引き続き機能します。なお、kkdaiが「成功」しつつメタデータが欠ける場合はフォールバックは発火しません（成功＝即returnのため）。この点が許容できない場合は、順序ではなくメタデータ補完の設計が別途必要になります。

## テスト

- 追加: `TestNewEnhancedService_FetcherOrder`（`internal/youtube/composite_fetcher_test.go`）
  - `NewEnhancedService` が構築する `CompositeFetcher` の1番目が `*KkdaiFetcher`、2番目が `*DefaultFetcher` であることを表明し、将来のリファクタで順序が黙って退行しないよう保護します。
- 既存テストはすべてグリーン。

## 検証結果（すべてpass）

- `gofmt -l internal`: 差分なし
- `go build ./...`: 成功
- `go vet ./...`: 問題なし
- `go test ./internal/youtube/... -v`: 56 passed
- `go test ./... -short`: 118 passed（8 packages）
