### PR TITLE
feat: translate_transcriptで実翻訳(tlang)を実装

### DIFF
--- a/internal/youtube/default_fetcher.go
+++ b/internal/youtube/default_fetcher.go
@@ -111,6 +111,15 @@ func (s *EnhancedService) GetTranscript(ctx context.Context, videoIdentifier str
 	return response, nil
 }
 
+// TranslateTranscript overrides the promoted *Service method so that, when the target
+// language already exists as a native caption track, the retrieval flows through this
+// type's GetTranscript override (composite fetcher with kkdai fallback) instead of the
+// base scraper. The tlang auto-translation path still relies on the base scraper because
+// it needs the caption track's timedtext URL, which the kkdai fetcher does not expose.
+func (s *EnhancedService) TranslateTranscript(ctx context.Context, videoIdentifier, targetLanguage, sourceLanguage string) (*models.TranscriptResponse, error) {
+	return s.Service.translateTranscript(ctx, videoIdentifier, targetLanguage, sourceLanguage, s.GetTranscript)
+}
+
 // ListAvailableLanguages overrides to use composite fetcher
 func (s *EnhancedService) ListAvailableLanguages(ctx context.Context, videoIdentifier string) (*models.AvailableLanguagesResponse, error) {
 	videoID, err := s.extractVideoID(videoIdentifier)

--- a/internal/youtube/service.go
+++ b/internal/youtube/service.go
@@ -387,6 +387,17 @@ const transcriptTypeTranslated = "translated"
 // parameter is appended to a translatable source track's timedtext URL, which makes
 // YouTube return that track translated into targetLanguage on the fly.
 func (s *Service) TranslateTranscript(ctx context.Context, videoIdentifier, targetLanguage, sourceLanguage string) (*models.TranscriptResponse, error) {
+	return s.translateTranscript(ctx, videoIdentifier, targetLanguage, sourceLanguage, s.GetTranscript)
+}
+
+// translateTranscript implements TranslateTranscript. nativeFetch retrieves a native
+// caption track when targetLanguage already exists as one; it is injected because Go has
+// no virtual dispatch. When *EnhancedService passes its own GetTranscript method value,
+// the native-track retrieval flows through the composite fetcher (with kkdai fallback);
+// *Service passes its base implementation. The tlang auto-translation path always uses
+// the base scraper because it needs the caption track's timedtext URL, which the kkdai
+// fetcher does not expose.
+func (s *Service) translateTranscript(ctx context.Context, videoIdentifier, targetLanguage, sourceLanguage string, nativeFetch func(context.Context, string, []string, bool) (*models.TranscriptResponse, error)) (*models.TranscriptResponse, error) {
 	videoID, err := s.extractVideoID(videoIdentifier)
 	if err != nil {
 		return nil, &models.TranscriptError{
@@ -436,7 +447,7 @@ func (s *Service) TranslateTranscript(ctx context.Context, videoIdentifier, targ
 	for i := range captionTracks {
 		if languageCodeMatches(captionTracks[i].LanguageCode, targetLanguage) {
 			s.recordRateLimitSuccess()
-			return s.GetTranscript(ctx, videoID, []string{targetLanguage}, false)
+			return nativeFetch(ctx, videoID, []string{targetLanguage}, false)
 		}
 	}
 

--- a/internal/youtube/service.go
+++ b/internal/youtube/service.go
@@ -373,30 +373,208 @@ func (s *Service) ListAvailableLanguages(ctx context.Context, videoIdentifier st
 	return response, nil
 }
 
-// TranslateTranscript translates a transcript to target language
+// translatedSourceMarker is recorded in TranscriptMetadata.Source when a transcript
+// is produced via YouTube's auto-translation instead of a native caption track.
+const translatedSourceMarker = "youtube-translated"
+
+// transcriptTypeTranslated marks a transcript produced via YouTube auto-translation.
+const transcriptTypeTranslated = "translated"
+
+// TranslateTranscript returns the transcript of a video in targetLanguage.
+//
+// If the video already has a native caption track in targetLanguage, that track is
+// returned directly. Otherwise it uses YouTube's auto-translation: the "tlang" query
+// parameter is appended to a translatable source track's timedtext URL, which makes
+// YouTube return that track translated into targetLanguage on the fly.
 func (s *Service) TranslateTranscript(ctx context.Context, videoIdentifier, targetLanguage, sourceLanguage string) (*models.TranscriptResponse, error) {
-	// First get available languages
-	availableLanguages, err := s.ListAvailableLanguages(ctx, videoIdentifier)
+	videoID, err := s.extractVideoID(videoIdentifier)
+	if err != nil {
+		return nil, &models.TranscriptError{
+			Type:    models.ErrorTypeInvalidVideoID,
+			Message: fmt.Sprintf("Invalid video identifier: %s", err.Error()),
+			VideoID: videoIdentifier,
+		}
+	}
+
+	// Distinct cache key so auto-translated results never collide with native transcripts.
+	cacheKey := fmt.Sprintf("%s%s:tlang:%s:%s", models.CacheKeyPrefixTranscript, videoID, sourceLanguage, targetLanguage)
+	if cached, found := s.cache.Get(ctx, cacheKey); found {
+		if transcript, ok := cached.(*models.TranscriptResponse); ok {
+			s.logger.Debug("Returning cached translated transcript",
+				slog.String("video_id", videoID),
+				slog.String("target_language", targetLanguage))
+			return transcript, nil
+		}
+	}
+
+	// Respect rate limits before making any network calls.
+	if waitErr := s.waitForRateLimit(ctx); waitErr != nil {
+		return nil, &models.TranscriptError{
+			Type:    models.ErrorTypeRateLimitExceeded,
+			Message: fmt.Sprintf("Rate limit exceeded: %s", waitErr.Error()),
+			VideoID: videoID,
+		}
+	}
+
+	// Fetch the caption tracks available for this video.
+	videoData, err := s.fetchVideoData(ctx, videoID)
+	if err != nil {
+		s.recordRateLimitFailure(err)
+		return nil, err
+	}
+
+	captionTracks, err := s.extractCaptionTracks(videoData)
+	if err != nil {
+		return nil, &models.TranscriptError{
+			Type:    models.ErrorTypeNoTranscriptFound,
+			Message: fmt.Sprintf("No captions found: %s", err.Error()),
+			VideoID: videoID,
+		}
+	}
+
+	// If a native caption track already exists in the target language, return it directly.
+	for i := range captionTracks {
+		if languageCodeMatches(captionTracks[i].LanguageCode, targetLanguage) {
+			s.recordRateLimitSuccess()
+			return s.GetTranscript(ctx, videoID, []string{targetLanguage}, false)
+		}
+	}
+
+	// Otherwise pick a translatable source track and use YouTube's auto-translation.
+	sourceTrack := s.selectTranslationSourceTrack(captionTracks, sourceLanguage)
+	if sourceTrack == nil {
+		return nil, &models.TranscriptError{
+			Type:        models.ErrorTypeLanguageNotAvailable,
+			Message:     fmt.Sprintf("No translatable caption track available to translate into %q", targetLanguage),
+			VideoID:     videoID,
+			Suggestions: s.getAvailableLanguageCodes(captionTracks),
+		}
+	}
+
+	response, err := s.fetchTranslatedTranscript(ctx, videoData, sourceTrack, targetLanguage)
+	if err != nil {
+		s.recordRateLimitFailure(err)
+		return nil, err
+	}
+
+	// Cache the translated result.
+	if err := s.cache.Set(ctx, cacheKey, response, s.config.RequestTimeout); err != nil {
+		s.logger.Warn("Failed to cache translated transcript response", "error", err)
+	}
+
+	s.recordRateLimitSuccess()
+	return response, nil
+}
+
+// selectTranslationSourceTrack picks the best translatable caption track to feed into
+// YouTube's tlang auto-translation. Only translatable tracks are eligible because a
+// non-translatable track cannot be auto-translated; nil is returned when none exist.
+// Preference order: a translatable track matching sourceLanguage, then the default
+// translatable track, then the first translatable track.
+func (s *Service) selectTranslationSourceTrack(tracks []CaptionTrack, sourceLanguage string) *CaptionTrack {
+	// 1. Prefer a translatable track matching the requested source language.
+	if sourceLanguage != "" {
+		for i := range tracks {
+			if tracks[i].IsTranslatable && languageCodeMatches(tracks[i].LanguageCode, sourceLanguage) {
+				return &tracks[i]
+			}
+		}
+	}
+
+	// 2. Prefer the default translatable track.
+	for i := range tracks {
+		if tracks[i].IsTranslatable && tracks[i].IsDefault {
+			return &tracks[i]
+		}
+	}
+
+	// 3. Fall back to the first translatable track.
+	for i := range tracks {
+		if tracks[i].IsTranslatable {
+			return &tracks[i]
+		}
+	}
+
+	return nil
+}
+
+// fetchTranslatedTranscript fetches sourceTrack auto-translated into targetLanguage by
+// adding the tlang query parameter to its timedtext URL, then builds a TranscriptResponse.
+func (s *Service) fetchTranslatedTranscript(ctx context.Context, videoData *VideoData, sourceTrack *CaptionTrack, targetLanguage string) (*models.TranscriptResponse, error) {
+	translatedURL, err := addTranslationParam(sourceTrack.BaseURL, targetLanguage)
+	if err != nil {
+		return nil, &models.TranscriptError{
+			Type:    models.ErrorTypeParsingError,
+			Message: fmt.Sprintf("Failed to build translation URL: %s", err.Error()),
+			VideoID: videoData.VideoID,
+		}
+	}
+
+	// Clone the source track with the translated URL and target language so the existing
+	// fetch/parse helpers can be reused unchanged.
+	translatedTrack := *sourceTrack
+	translatedTrack.BaseURL = translatedURL
+	translatedTrack.LanguageCode = targetLanguage
+
+	s.logger.Debug("Fetching auto-translated transcript",
+		slog.String("video_id", videoData.VideoID),
+		slog.String("source_language", sourceTrack.LanguageCode),
+		slog.String("target_language", targetLanguage),
+		slog.String("url", translatedURL))
+
+	segments, err := s.fetchTranscriptFromTrack(ctx, &translatedTrack)
 	if err != nil {
 		return nil, err
 	}
 
-	// Check if target language is available
-	var targetFound bool
-	for _, lang := range availableLanguages.Languages {
-		if lang.Code == targetLanguage {
-			targetFound = true
-			break
-		}
+	response := &models.TranscriptResponse{
+		VideoID:        videoData.VideoID,
+		Title:          videoData.Title,
+		Description:    videoData.Description,
+		Language:       targetLanguage,
+		TranscriptType: transcriptTypeTranslated,
+		Transcript:     segments,
+		Metadata: models.TranscriptMetadata{
+			ExtractionTimestamp: time.Now().UTC(),
+			LanguageDetected:    targetLanguage,
+			Source:              translatedSourceMarker,
+			ChannelID:           videoData.ChannelID,
+			ChannelName:         videoData.ChannelName,
+			PublishedAt:         videoData.PublishedAt,
+			ViewCount:           videoData.ViewCount,
+			LikeCount:           videoData.LikeCount,
+			CommentCount:        videoData.CommentCount,
+		},
 	}
 
-	if !targetFound {
-		// Try to get auto-translated version
-		return s.GetTranscript(ctx, videoIdentifier, []string{targetLanguage}, false)
+	response.FormattedText = s.formatTranscriptText(segments)
+	response.WordCount = s.countWords(response.FormattedText)
+	response.CharCount = len(response.FormattedText)
+	response.DurationSeconds = s.calculateDuration(segments)
+
+	return response, nil
+}
+
+// addTranslationParam returns baseURL with the YouTube auto-translation query parameter
+// (tlang) set to targetLanguage. Existing query parameters are preserved.
+func addTranslationParam(baseURL, targetLanguage string) (string, error) {
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return "", err
 	}
 
-	// Get transcript in target language
-	return s.GetTranscript(ctx, videoIdentifier, []string{targetLanguage}, false)
+	q := u.Query()
+	q.Set("tlang", targetLanguage)
+	u.RawQuery = q.Encode()
+
+	return u.String(), nil
+}
+
+// languageCodeMatches reports whether a caption track's language code satisfies a
+// requested language, matching either exactly ("en" == "en") or by prefix ("en-US"
+// for requested "en").
+func languageCodeMatches(trackCode, requested string) bool {
+	return trackCode == requested || strings.HasPrefix(trackCode, requested+"-")
 }
 
 // FormatTranscript formats a transcript according to specified format

--- a/internal/youtube/service_test.go
+++ b/internal/youtube/service_test.go
@@ -1092,6 +1092,74 @@ func TestTranslateTranscript(t *testing.T) {
 	})
 }
 
+// TestEnhancedServiceTranslateTranscript verifies the *EnhancedService override of
+// TranslateTranscript. Without that override the promoted *Service.TranslateTranscript
+// runs, and its internal native-track GetTranscript call would bind to the base scraper
+// (Go has no virtual dispatch), bypassing the composite fetcher with kkdai fallback.
+func TestEnhancedServiceTranslateTranscript(t *testing.T) {
+	t.Run("auto-translates via tlang through EnhancedService", func(t *testing.T) {
+		var timedtextTLang string
+		var timedtextHit bool
+		server := newTranslateTestServer(t,
+			[]CaptionTrack{{LanguageCode: "en", IsTranslatable: true, IsDefault: true}},
+			func(r *http.Request) {
+				timedtextHit = true
+				timedtextTLang = r.URL.Query().Get("tlang")
+			},
+		)
+		defer server.Close()
+
+		enhanced := NewEnhancedService(newTranslateTestService(t, server))
+
+		resp, err := enhanced.TranslateTranscript(context.Background(), "abc123video", "ja", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !timedtextHit {
+			t.Fatal("expected timedtext endpoint to be called")
+		}
+		if timedtextTLang != "ja" {
+			t.Errorf("expected tlang=ja, got %q", timedtextTLang)
+		}
+		if resp.TranscriptType != transcriptTypeTranslated {
+			t.Errorf("expected translated transcript type, got %q", resp.TranscriptType)
+		}
+	})
+
+	t.Run("native target track delegates to the GetTranscript override", func(t *testing.T) {
+		server := newTranslateTestServer(t,
+			[]CaptionTrack{
+				{LanguageCode: "en", IsTranslatable: true, IsDefault: true},
+				{LanguageCode: "ja", IsTranslatable: false},
+			},
+			func(r *http.Request) {
+				if r.URL.Query().Has("tlang") {
+					t.Errorf("native track must not be auto-translated, saw tlang=%q", r.URL.Query().Get("tlang"))
+				}
+			},
+		)
+		defer server.Close()
+
+		base := newTranslateTestService(t, server)
+		enhanced := NewEnhancedService(base)
+
+		resp, err := enhanced.TranslateTranscript(context.Background(), "abc123video", "ja", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.Language != "ja" {
+			t.Errorf("expected Language=ja, got %q", resp.Language)
+		}
+		// The native retrieval must delegate to GetTranscript, which caches under the
+		// normal transcript key (distinct from the tlang key); its presence confirms the
+		// native path is served through GetTranscript rather than the tlang path.
+		normalKey := fmt.Sprintf("%sabc123video:ja", models.CacheKeyPrefixTranscript)
+		if _, found := base.cache.Get(context.Background(), normalKey); !found {
+			t.Errorf("expected native retrieval to populate normal transcript cache key %q", normalKey)
+		}
+	})
+}
+
 // newTranslateTestServer serves a YouTube-like watch page whose caption tracks point
 // back at the same server's /api/timedtext endpoint. onTimedtext, when non-nil, is
 // invoked for each timedtext request so tests can assert on the query parameters.

--- a/internal/youtube/service_test.go
+++ b/internal/youtube/service_test.go
@@ -2,9 +2,12 @@ package youtube
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -756,4 +759,381 @@ func TestAdaptiveRateLimit(t *testing.T) {
 			t.Error("Expected multiplier to remain unchanged")
 		}
 	})
+}
+
+func TestLanguageCodeMatches(t *testing.T) {
+	tests := []struct {
+		trackCode string
+		requested string
+		expected  bool
+	}{
+		{"en", "en", true},
+		{"en-US", "en", true},
+		{"en", "en-US", false},
+		{"es", "en", false},
+		{"ja", "ja", true},
+		{"pt-BR", "pt", true},
+	}
+
+	for _, tt := range tests {
+		if got := languageCodeMatches(tt.trackCode, tt.requested); got != tt.expected {
+			t.Errorf("languageCodeMatches(%q, %q) = %v, want %v", tt.trackCode, tt.requested, got, tt.expected)
+		}
+	}
+}
+
+func TestAddTranslationParam(t *testing.T) {
+	t.Run("adds tlang preserving existing params", func(t *testing.T) {
+		out, err := addTranslationParam("https://www.youtube.com/api/timedtext?v=abc&lang=en", "ja")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		u, err := url.Parse(out)
+		if err != nil {
+			t.Fatalf("result is not a valid URL: %v", err)
+		}
+		q := u.Query()
+		if q.Get("tlang") != "ja" {
+			t.Errorf("expected tlang=ja, got %q", q.Get("tlang"))
+		}
+		if q.Get("v") != "abc" {
+			t.Errorf("expected v=abc preserved, got %q", q.Get("v"))
+		}
+		if q.Get("lang") != "en" {
+			t.Errorf("expected lang=en preserved, got %q", q.Get("lang"))
+		}
+	})
+
+	t.Run("overwrites existing tlang", func(t *testing.T) {
+		out, err := addTranslationParam("https://www.youtube.com/api/timedtext?v=abc&tlang=fr", "ja")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		u, _ := url.Parse(out)
+		if got := u.Query().Get("tlang"); got != "ja" {
+			t.Errorf("expected tlang overwritten to ja, got %q", got)
+		}
+	})
+
+	t.Run("invalid URL returns error", func(t *testing.T) {
+		if _, err := addTranslationParam("://not-a-url", "ja"); err == nil {
+			t.Error("expected error for invalid URL, got nil")
+		}
+	})
+}
+
+func TestSelectTranslationSourceTrack(t *testing.T) {
+	s := &Service{}
+
+	tracks := []CaptionTrack{
+		{LanguageCode: "en", IsTranslatable: true, IsDefault: true},
+		{LanguageCode: "ja", IsTranslatable: true},
+		{LanguageCode: "ko", IsTranslatable: false},
+	}
+
+	tests := []struct {
+		name           string
+		sourceLanguage string
+		tracks         []CaptionTrack
+		expectNil      bool
+		expectedCode   string
+	}{
+		{
+			name:           "matches requested source language",
+			sourceLanguage: "ja",
+			tracks:         tracks,
+			expectedCode:   "ja",
+		},
+		{
+			name:           "prefers default translatable when no source given",
+			sourceLanguage: "",
+			tracks:         tracks,
+			expectedCode:   "en",
+		},
+		{
+			name:           "falls back to first translatable when source not found",
+			sourceLanguage: "fr",
+			tracks:         tracks,
+			expectedCode:   "en",
+		},
+		{
+			name:           "first translatable when no default",
+			sourceLanguage: "",
+			tracks:         []CaptionTrack{{LanguageCode: "ko", IsTranslatable: false}, {LanguageCode: "ja", IsTranslatable: true}},
+			expectedCode:   "ja",
+		},
+		{
+			name:           "nil when no translatable tracks",
+			sourceLanguage: "",
+			tracks:         []CaptionTrack{{LanguageCode: "ko", IsTranslatable: false}},
+			expectNil:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := s.selectTranslationSourceTrack(tt.tracks, tt.sourceLanguage)
+			if tt.expectNil {
+				if got != nil {
+					t.Errorf("expected nil track, got %+v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("expected a track but got nil")
+			}
+			if got.LanguageCode != tt.expectedCode {
+				t.Errorf("expected language %q, got %q", tt.expectedCode, got.LanguageCode)
+			}
+		})
+	}
+}
+
+// newTestService builds a Service backed by a mock cache and generous rate limits,
+// suitable for exercising the network paths against an httptest server.
+func newTestService() *Service {
+	cfg := config.YouTubeConfig{
+		DefaultLanguages:   []string{"en"},
+		RequestTimeout:     30 * time.Second,
+		RetryAttempts:      2,
+		RetryDelay:         time.Millisecond,
+		RateLimitPerMinute: 6000,
+		RateLimitPerHour:   60000,
+		UserAgent:          "test-agent",
+	}
+	return NewService(cfg, newMockCache(), slog.Default())
+}
+
+// hostRewriteTransport redirects every outgoing request to a fixed target host
+// (the httptest server) while preserving the path and query, so code that hardcodes
+// www.youtube.com can be tested without live network access.
+type hostRewriteTransport struct {
+	base   http.RoundTripper
+	target *url.URL
+}
+
+func (t *hostRewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.URL.Scheme = t.target.Scheme
+	req.URL.Host = t.target.Host
+	return t.base.RoundTrip(req)
+}
+
+const jaTranslatedXML = `<?xml version="1.0" encoding="utf-8"?>
+<transcript>
+	<text start="0" dur="2">こんにちは世界</text>
+	<text start="2" dur="3">これはテストです</text>
+</transcript>`
+
+func buildWatchHTML(t *testing.T, tracks []CaptionTrack) string {
+	t.Helper()
+	pr := PlayerResponse{
+		VideoDetails: &VideoDetails{
+			Title:     "Test Video",
+			ChannelID: "chan-1",
+			Author:    "Author",
+			ViewCount: "100",
+		},
+		Captions: &Captions{
+			PlayerCaptionsTracklistRenderer: PlayerCaptionsTracklistRenderer{
+				CaptionTracks: tracks,
+			},
+		},
+	}
+	b, err := json.Marshal(pr)
+	if err != nil {
+		t.Fatalf("failed to marshal player response: %v", err)
+	}
+	// The parser extracts a single-line `var ytInitialPlayerResponse = {...};` assignment.
+	return "<html><body><script>var ytInitialPlayerResponse = " + string(b) + ";</script></body></html>"
+}
+
+func TestFetchTranslatedTranscript(t *testing.T) {
+	var capturedTLang string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedTLang = r.URL.Query().Get("tlang")
+		w.Header().Set("Content-Type", "application/xml")
+		_, _ = w.Write([]byte(jaTranslatedXML))
+	}))
+	defer server.Close()
+
+	s := newTestService()
+
+	sourceTrack := &CaptionTrack{
+		BaseURL:        server.URL + "/api/timedtext?v=abc&lang=en",
+		LanguageCode:   "en",
+		IsTranslatable: true,
+	}
+	videoData := &VideoData{VideoID: "abc123video", Title: "Test Video", ChannelName: "Author"}
+
+	resp, err := s.fetchTranslatedTranscript(context.Background(), videoData, sourceTrack, "ja")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if capturedTLang != "ja" {
+		t.Errorf("expected tlang=ja sent to timedtext endpoint, got %q", capturedTLang)
+	}
+	if resp.Language != "ja" {
+		t.Errorf("expected Language=ja, got %q", resp.Language)
+	}
+	if resp.TranscriptType != transcriptTypeTranslated {
+		t.Errorf("expected TranscriptType=%q, got %q", transcriptTypeTranslated, resp.TranscriptType)
+	}
+	if resp.Metadata.Source != translatedSourceMarker {
+		t.Errorf("expected Source=%q, got %q", translatedSourceMarker, resp.Metadata.Source)
+	}
+	if len(resp.Transcript) != 2 {
+		t.Fatalf("expected 2 segments, got %d", len(resp.Transcript))
+	}
+	if resp.Transcript[0].Text != "こんにちは世界" {
+		t.Errorf("unexpected first segment text: %q", resp.Transcript[0].Text)
+	}
+}
+
+func TestTranslateTranscript(t *testing.T) {
+	t.Run("auto-translates via tlang when target track is missing", func(t *testing.T) {
+		var timedtextTLang string
+		var timedtextHit bool
+		server := newTranslateTestServer(t,
+			[]CaptionTrack{{
+				LanguageCode:   "en",
+				IsTranslatable: true,
+				IsDefault:      true,
+			}},
+			func(r *http.Request) {
+				timedtextHit = true
+				timedtextTLang = r.URL.Query().Get("tlang")
+			},
+		)
+		defer server.Close()
+
+		s := newTranslateTestService(t, server)
+
+		resp, err := s.TranslateTranscript(context.Background(), "abc123video", "ja", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !timedtextHit {
+			t.Fatal("expected timedtext endpoint to be called")
+		}
+		if timedtextTLang != "ja" {
+			t.Errorf("expected tlang=ja, got %q", timedtextTLang)
+		}
+		if resp.Language != "ja" {
+			t.Errorf("expected Language=ja, got %q", resp.Language)
+		}
+		if resp.TranscriptType != transcriptTypeTranslated {
+			t.Errorf("expected translated transcript type, got %q", resp.TranscriptType)
+		}
+		if resp.Metadata.Source != translatedSourceMarker {
+			t.Errorf("expected source marker %q, got %q", translatedSourceMarker, resp.Metadata.Source)
+		}
+		if len(resp.Transcript) != 2 {
+			t.Errorf("expected 2 segments, got %d", len(resp.Transcript))
+		}
+	})
+
+	t.Run("returns native track without tlang when target exists", func(t *testing.T) {
+		var timedtextTLang string
+		var sawTLang bool
+		server := newTranslateTestServer(t,
+			[]CaptionTrack{
+				{LanguageCode: "en", IsTranslatable: true, IsDefault: true},
+				{LanguageCode: "ja", IsTranslatable: false},
+			},
+			func(r *http.Request) {
+				if r.URL.Query().Has("tlang") {
+					sawTLang = true
+					timedtextTLang = r.URL.Query().Get("tlang")
+				}
+			},
+		)
+		defer server.Close()
+
+		s := newTranslateTestService(t, server)
+
+		resp, err := s.TranslateTranscript(context.Background(), "abc123video", "ja", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if sawTLang {
+			t.Errorf("expected no tlang for native track, but saw tlang=%q", timedtextTLang)
+		}
+		if resp.Language != "ja" {
+			t.Errorf("expected Language=ja, got %q", resp.Language)
+		}
+	})
+
+	t.Run("errors when no translatable track exists", func(t *testing.T) {
+		server := newTranslateTestServer(t,
+			[]CaptionTrack{{LanguageCode: "en", IsTranslatable: false, IsDefault: true}},
+			nil,
+		)
+		defer server.Close()
+
+		s := newTranslateTestService(t, server)
+
+		_, err := s.TranslateTranscript(context.Background(), "abc123video", "ja", "")
+		if err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+		var transcriptErr *models.TranscriptError
+		if te, ok := err.(*models.TranscriptError); ok {
+			transcriptErr = te
+		} else {
+			t.Fatalf("expected *models.TranscriptError, got %T", err)
+		}
+		if transcriptErr.Type != models.ErrorTypeLanguageNotAvailable {
+			t.Errorf("expected error type %q, got %q", models.ErrorTypeLanguageNotAvailable, transcriptErr.Type)
+		}
+		if len(transcriptErr.Suggestions) == 0 || transcriptErr.Suggestions[0] != "en" {
+			t.Errorf("expected suggestions to list available languages, got %v", transcriptErr.Suggestions)
+		}
+	})
+}
+
+// newTranslateTestServer serves a YouTube-like watch page whose caption tracks point
+// back at the same server's /api/timedtext endpoint. onTimedtext, when non-nil, is
+// invoked for each timedtext request so tests can assert on the query parameters.
+func newTranslateTestServer(t *testing.T, tracks []CaptionTrack, onTimedtext func(*http.Request)) *httptest.Server {
+	t.Helper()
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/api/timedtext"):
+			if onTimedtext != nil {
+				onTimedtext(r)
+			}
+			w.Header().Set("Content-Type", "application/xml")
+			_, _ = w.Write([]byte(jaTranslatedXML))
+		case strings.HasPrefix(r.URL.Path, "/watch"):
+			// Point caption track baseUrls at this server's timedtext endpoint.
+			resolved := make([]CaptionTrack, len(tracks))
+			for i, tr := range tracks {
+				tr.BaseURL = server.URL + "/api/timedtext?v=abc123video&lang=" + tr.LanguageCode
+				resolved[i] = tr
+			}
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = w.Write([]byte(buildWatchHTML(t, resolved)))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	return server
+}
+
+// newTranslateTestService returns a Service whose HTTP client redirects all requests
+// (including the hardcoded www.youtube.com watch URL) to the test server.
+func newTranslateTestService(t *testing.T, server *httptest.Server) *Service {
+	t.Helper()
+	s := newTestService()
+	target, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("failed to parse server URL: %v", err)
+	}
+	s.httpClient.Transport = &hostRewriteTransport{
+		base:   http.DefaultTransport,
+		target: target,
+	}
+	return s
 }


### PR DESCRIPTION
## 概要

`translate_transcript` ツールが実際には翻訳を行っていなかった問題を修正し、YouTube の自動翻訳機能（`tlang`）を使った実翻訳を実装しました。

## Before（修正前: 実質no-op）

`internal/youtube/service.go` の `TranslateTranscript` は、対象言語が存在しても存在しなくても、両方の分岐で同じ処理をしていました。

```go
if !targetFound {
    return s.GetTranscript(ctx, videoIdentifier, []string{targetLanguage}, false)
}
return s.GetTranscript(ctx, videoIdentifier, []string{targetLanguage}, false)
```

- `sourceLanguage` 引数は完全に無視。
- YouTube の翻訳機能を一切使っていない。
- そのため「字幕トラックが存在しない言語」へ翻訳しようとすると、単に `LANGUAGE_NOT_AVAILABLE` で失敗するだけだった（＝翻訳になっていない）。

## After（修正後: 実翻訳）

`TranslateTranscript` を次のように再実装しました。

1. **ネイティブtrackが既にある場合**: 対象言語の字幕トラックが既に存在すれば、そのトラックをそのまま返す（従来挙動を踏襲）。
2. **無い場合は自動翻訳**: 翻訳元トラックを選び、その timedtext の `BaseURL` にクエリパラメータ `tlang=<対象言語>` を付与して取得する。YouTube はこの URL に対し、当該トラックをリアルタイムで対象言語へ自動翻訳した字幕を返す。
3. **翻訳元が無い場合**: 翻訳可能（`isTranslatable`）なトラックが1つも無ければ、利用可能言語一覧を `Suggestions` に入れて `LANGUAGE_NOT_AVAILABLE` を返す。

### tlang のメカニズム

YouTube の字幕取得 URL（timedtext）に `&tlang=ja` のように対象言語コードを付けると、サーバ側が元字幕を自動翻訳したものを返します。本実装では `net/url` で `BaseURL` をパースし、`tlang` クエリを `Set` してから再エンコードすることで、既存のクエリパラメータ（署名等）を保ったまま安全に付与しています。

### source-language の扱い

翻訳元トラックの選択優先順位（翻訳可能トラックのみが対象）:

1. `sourceLanguage` に一致する翻訳可能トラック（指定があれば。完全一致 or `en` → `en-US` のような prefix 一致）
2. デフォルトの翻訳可能トラック
3. 最初の翻訳可能トラック

`tlang` による自動翻訳は元トラックが翻訳可能でなければ機能しないため、選択対象を「翻訳可能トラック」に限定しています。1つも無ければ上記3.でエラーを返します。

### キャッシュキー

通常のトランスクリプト（`transcript:<videoID>:<langs>`）と衝突しないよう、翻訳結果には `tlang` マーカーと対象言語を含む専用キーを使用します:

```
transcript:<videoID>:tlang:<sourceLanguage>:<targetLanguage>
```

レスポンスのメタデータは自動翻訳由来であることを示すよう、`Metadata.Source = "youtube-translated"`、`TranscriptType = "translated"` を設定します。

## 変更ファイル

- `internal/youtube/service.go`: `TranslateTranscript` 再実装 + ヘルパ追加（`selectTranslationSourceTrack` / `fetchTranslatedTranscript` / `addTranslationParam` / `languageCodeMatches`）。既存の取得・パース・整形ヘルパを再利用。
- `internal/youtube/service_test.go`: ユニットテスト追加。

## テスト計画

`httptest` で watch ページと timedtext レスポンスをモックして検証（live youtube.com には依存しない）:

- `TestAddTranslationParam`: 既存クエリを保持して `tlang` を付与/上書き、不正 URL でエラー。
- `TestSelectTranslationSourceTrack`: source 一致 / デフォルト / 先頭 / 翻訳不可のみで nil。
- `TestLanguageCodeMatches`: 完全一致・prefix一致。
- `TestFetchTranslatedTranscript`: timedtext へ `tlang=ja` が送られ、XML がパースされ `Language=ja` / `TranscriptType=translated` / `Source=youtube-translated` のレスポンスになる。
- `TestTranslateTranscript`:
  - 対象trackが無い → `tlang` 経由で自動翻訳される
  - 対象trackがネイティブで存在 → `tlang` を付けずにそのトラックを返す
  - 翻訳可能trackが無い → `LANGUAGE_NOT_AVAILABLE` + suggestions

### 正直な注記（live カバレッジ）

これらのテストはモック HTTP サーバに対するもので、`tlang` パラメータが正しく付与され、レスポンスが正しくパース・整形されることを検証します。一方で、**実際の YouTube が `tlang` に対して期待通り翻訳字幕を返すかどうかという真の end-to-end 挙動は YouTube 側に依存し、ネットワークテストではカバーしていません**。実運用での確認は別途必要です。

## 検証

- `gofmt -l internal`: 差分なし
- `go build ./...`: 成功
- `go test ./internal/youtube/... -v`: 全 pass
- `go test ./... -short`: 全 pass（8 packages）
- `go vet ./...`: 問題なし
