### PR TITLE
fix: キャッシュTTL設定を実際に配線(RequestTimeout誤用の修正)

### DIFF
--- a/cmd/mcp/main.go
+++ b/cmd/mcp/main.go
@@ -67,7 +67,7 @@ func main() {
 	}()
 
 	// Initialize YouTube service with fallback support
-	baseService := youtube.NewService(cfg.YouTube, cacheInstance, logger)
+	baseService := youtube.NewService(cfg.YouTube, cfg.Cache, cacheInstance, logger)
 	youtubeService := youtube.NewEnhancedService(baseService)
 
 	// Initialize MCP server

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -69,7 +69,7 @@ func main() {
 	}()
 
 	// Initialize YouTube service with fallback support
-	baseService := youtube.NewService(cfg.YouTube, cacheInstance, logger)
+	baseService := youtube.NewService(cfg.YouTube, cfg.Cache, cacheInstance, logger)
 	youtubeService := youtube.NewEnhancedService(baseService)
 
 	// Initialize MCP server

--- a/internal/youtube/default_fetcher.go
+++ b/internal/youtube/default_fetcher.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/kyong0612/youtube-mcp/internal/models"
 )
@@ -104,7 +103,7 @@ func (s *EnhancedService) GetTranscript(ctx context.Context, videoIdentifier str
 	}
 
 	// Cache the result
-	if err := s.cache.Set(ctx, cacheKey, response, time.Hour*24); err != nil {
+	if err := s.cache.Set(ctx, cacheKey, response, s.transcriptTTL); err != nil {
 		s.logger.Warn("Failed to cache transcript response", "error", err)
 	}
 
@@ -137,7 +136,7 @@ func (s *EnhancedService) ListAvailableLanguages(ctx context.Context, videoIdent
 	}
 
 	// Cache the result
-	if err := s.cache.Set(ctx, cacheKey, response, time.Hour*6); err != nil {
+	if err := s.cache.Set(ctx, cacheKey, response, s.languagesTTL); err != nil {
 		s.logger.Warn("Failed to cache languages response", "error", err)
 	}
 

--- a/internal/youtube/service.go
+++ b/internal/youtube/service.go
@@ -32,6 +32,8 @@ type Service struct {
 	proxyManager   *ProxyManager
 	logger         *slog.Logger
 	rateLimitState *RateLimitState
+	transcriptTTL  time.Duration
+	languagesTTL   time.Duration
 	config         config.YouTubeConfig
 }
 
@@ -52,7 +54,7 @@ type ProxyManager struct {
 }
 
 // NewService creates a new YouTube service instance
-func NewService(cfg config.YouTubeConfig, cache cache.Cache, logger *slog.Logger) *Service {
+func NewService(cfg config.YouTubeConfig, cacheCfg config.CacheConfig, cache cache.Cache, logger *slog.Logger) *Service {
 	// Create HTTP client with custom transport
 	transport := &http.Transport{
 		MaxIdleConns:        100,
@@ -104,6 +106,17 @@ func NewService(cfg config.YouTubeConfig, cache cache.Cache, logger *slog.Logger
 	rateLimiter := rate.NewLimiter(rate.Every(time.Minute/time.Duration(rateLimitPerMinute)), rateLimitPerMinute)
 	hourlyLimiter := rate.NewLimiter(rate.Every(time.Hour/time.Duration(rateLimitPerHour)), rateLimitPerHour)
 
+	// Resolve cache TTLs with safe defaults when unset (a zero TTL would expire
+	// entries immediately given MemoryCache's time.Since(ts) > ttl check).
+	transcriptTTL := cacheCfg.TranscriptTTL
+	if transcriptTTL <= 0 {
+		transcriptTTL = 24 * time.Hour
+	}
+	languagesTTL := cacheCfg.LanguagesTTL
+	if languagesTTL <= 0 {
+		languagesTTL = 6 * time.Hour
+	}
+
 	return &Service{
 		config:        cfg,
 		httpClient:    httpClient,
@@ -112,6 +125,8 @@ func NewService(cfg config.YouTubeConfig, cache cache.Cache, logger *slog.Logger
 		hourlyLimiter: hourlyLimiter,
 		proxyManager:  proxyManager,
 		logger:        logger,
+		transcriptTTL: transcriptTTL,
+		languagesTTL:  languagesTTL,
 		rateLimitState: &RateLimitState{
 			adaptiveMultiplier: 1.0,
 		},
@@ -219,7 +234,7 @@ func (s *Service) GetTranscript(ctx context.Context, videoIdentifier string, lan
 	response.DurationSeconds = s.calculateDuration(transcript)
 
 	// Cache the result
-	if err := s.cache.Set(ctx, cacheKey, response, s.config.RequestTimeout); err != nil {
+	if err := s.cache.Set(ctx, cacheKey, response, s.transcriptTTL); err != nil {
 		s.logger.Warn("Failed to cache transcript response", "error", err)
 	}
 
@@ -366,7 +381,7 @@ func (s *Service) ListAvailableLanguages(ctx context.Context, videoIdentifier st
 	}
 
 	// Cache the result
-	if err := s.cache.Set(ctx, cacheKey, response, s.config.RequestTimeout); err != nil {
+	if err := s.cache.Set(ctx, cacheKey, response, s.languagesTTL); err != nil {
 		s.logger.Warn("Failed to cache transcript response", "error", err)
 	}
 

--- a/internal/youtube/service_test.go
+++ b/internal/youtube/service_test.go
@@ -3,7 +3,9 @@ package youtube
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -18,11 +20,13 @@ import (
 // Mock cache for testing
 type mockCache struct {
 	data map[string]any
+	ttls map[string]time.Duration
 }
 
 func newMockCache() *mockCache {
 	return &mockCache{
 		data: make(map[string]any),
+		ttls: make(map[string]time.Duration),
 	}
 }
 
@@ -33,6 +37,7 @@ func (m *mockCache) Get(ctx context.Context, key string) (any, bool) {
 
 func (m *mockCache) Set(ctx context.Context, key string, value any, ttl time.Duration) error {
 	m.data[key] = value
+	m.ttls[key] = ttl
 	return nil
 }
 
@@ -498,7 +503,7 @@ func TestServiceWithCache(t *testing.T) {
 	mockCache := newMockCache()
 	logger := slog.Default()
 
-	service := NewService(cfg, mockCache, logger)
+	service := NewService(cfg, config.CacheConfig{}, mockCache, logger)
 
 	// Test that service is properly initialized
 	if service.config.UserAgent != "test-agent" {
@@ -755,5 +760,90 @@ func TestAdaptiveRateLimit(t *testing.T) {
 		if s.rateLimitState.adaptiveMultiplier != initialMultiplier {
 			t.Error("Expected multiplier to remain unchanged")
 		}
+	})
+}
+
+// roundTripFunc adapts a function to an http.RoundTripper for stubbing responses.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+// TestCacheTTLConfiguration verifies that the cache TTLs configured via
+// CacheConfig (CACHE_TRANSCRIPT_TTL / CACHE_LANGUAGES_TTL) are the values
+// actually passed to cache.Set, and that a zero TTL falls back to the defaults.
+func TestCacheTTLConfiguration(t *testing.T) {
+	// Single-line player response so the ytInitialPlayerResponse regex matches.
+	playerJSON := `{"videoDetails":{"videoId":"testvideo01","title":"T","author":"A","channelId":"C","viewCount":"1"},"captions":{"playerCaptionsTracklistRenderer":{"captionTracks":[{"baseUrl":"https://transcript.test/track","languageCode":"en","isDefault":true}]}}}`
+	watchHTML := "var ytInitialPlayerResponse = " + playerJSON + ";"
+	transcriptXML := `<?xml version="1.0" encoding="utf-8"?><transcript><text start="0" dur="2">Hello world</text></transcript>`
+
+	newStubService := func(cacheCfg config.CacheConfig, mc *mockCache) *Service {
+		ycfg := config.YouTubeConfig{
+			DefaultLanguages:   []string{"en"},
+			RequestTimeout:     30 * time.Second,
+			RateLimitPerMinute: 600,
+			RateLimitPerHour:   10000,
+			UserAgent:          "test-agent",
+		}
+		svc := NewService(ycfg, cacheCfg, mc, slog.Default())
+		svc.httpClient = &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			body := watchHTML
+			if strings.Contains(r.URL.Host, "transcript.test") {
+				body = transcriptXML
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     make(http.Header),
+			}, nil
+		})}
+		return svc
+	}
+
+	containsTTL := func(t *testing.T, mc *mockCache, want time.Duration) {
+		t.Helper()
+		for key, ttl := range mc.ttls {
+			if ttl == want {
+				return
+			}
+			t.Logf("recorded ttl for %q: %s", key, ttl)
+		}
+		t.Errorf("expected cache.Set to receive ttl %s, recorded: %v", want, mc.ttls)
+	}
+
+	t.Run("transcript uses configured TTL", func(t *testing.T) {
+		mc := newMockCache()
+		svc := newStubService(config.CacheConfig{TranscriptTTL: 2 * time.Hour}, mc)
+		if _, err := svc.GetTranscript(context.Background(), "testvideo01", []string{"en"}, false); err != nil {
+			t.Fatalf("GetTranscript failed: %v", err)
+		}
+		containsTTL(t, mc, 2*time.Hour)
+	})
+
+	t.Run("languages uses configured TTL", func(t *testing.T) {
+		mc := newMockCache()
+		svc := newStubService(config.CacheConfig{LanguagesTTL: 3 * time.Hour}, mc)
+		if _, err := svc.ListAvailableLanguages(context.Background(), "testvideo01"); err != nil {
+			t.Fatalf("ListAvailableLanguages failed: %v", err)
+		}
+		containsTTL(t, mc, 3*time.Hour)
+	})
+
+	t.Run("zero transcript TTL falls back to 24h", func(t *testing.T) {
+		mc := newMockCache()
+		svc := newStubService(config.CacheConfig{}, mc)
+		if _, err := svc.GetTranscript(context.Background(), "testvideo01", []string{"en"}, false); err != nil {
+			t.Fatalf("GetTranscript failed: %v", err)
+		}
+		containsTTL(t, mc, 24*time.Hour)
+	})
+
+	t.Run("zero languages TTL falls back to 6h", func(t *testing.T) {
+		mc := newMockCache()
+		svc := newStubService(config.CacheConfig{}, mc)
+		if _, err := svc.ListAvailableLanguages(context.Background(), "testvideo01"); err != nil {
+			t.Fatalf("ListAvailableLanguages failed: %v", err)
+		}
+		containsTTL(t, mc, 6*time.Hour)
 	})
 }


### PR DESCRIPTION
## 概要

キャッシュの有効期限(TTL)に関する設定 `CACHE_TRANSCRIPT_TTL` / `CACHE_LANGUAGES_TTL` が、実際にはキャッシュエントリの寿命に反映されておらず「死んだ設定(dead config)」になっていた問題を修正します。あわせて、HTTPリクエストのタイムアウト値(`RequestTimeout`、約30秒)をキャッシュ寿命として流用していた誤用を解消します。

## 問題(修正前の挙動)

- `internal/config/config.go:277-280` で `CacheConfig.TranscriptTTL`(既定24h)/`MetadataTTL`(1h)/`LanguagesTTL`(6h)/`ErrorTTL`(15m)を環境変数から読み込んでいたが、これらは一切キャッシュのTTL設定に使われていなかった。
- `internal/youtube/service.go:222`(トランスクリプト)と `internal/youtube/service.go:369`(言語一覧)では、キャッシュ保存時のTTLに `s.config.RequestTimeout` を渡していた。`RequestTimeout` は1リクエストあたりのHTTPタイムアウト(約30秒)であり、キャッシュ寿命としては不適切。結果として、本来24時間/6時間保持されるべきキャッシュが約30秒で失効していた。
- `internal/youtube/default_fetcher.go:107` では `time.Hour*24`、`internal/youtube/default_fetcher.go:140` では `time.Hour*6` がハードコードされており、設定値が無視されていた。

つまり `CACHE_TRANSCRIPT_TTL` や `CACHE_LANGUAGES_TTL` を環境変数で指定しても効果がなかった。

## 修正内容

### シグネチャ変更と呼び出し側の更新

- `Service` 構造体に `transcriptTTL`, `languagesTTL`(いずれも `time.Duration`)フィールドを追加。
- `NewService` に `config.CacheConfig` 引数を追加し、上記フィールドを設定するように変更。
  - 変更前: `NewService(cfg config.YouTubeConfig, cache cache.Cache, logger *slog.Logger)`
  - 変更後: `NewService(cfg config.YouTubeConfig, cacheCfg config.CacheConfig, cache cache.Cache, logger *slog.Logger)`
- 呼び出し側を更新:
  - `cmd/server/main.go`: `youtube.NewService(cfg.YouTube, cfg.Cache, cacheInstance, logger)`
  - `cmd/mcp/main.go`: `youtube.NewService(cfg.YouTube, cfg.Cache, cacheInstance, logger)`
  - `internal/youtube/service_test.go`: 既存の `TestServiceWithCache` の呼び出しを更新。

### TTLの実配線

- `internal/youtube/service.go:222` を `s.transcriptTTL` に変更。
- `internal/youtube/service.go:369` を `s.languagesTTL` に変更。
- `internal/youtube/default_fetcher.go:107` を `s.transcriptTTL` に変更。
- `internal/youtube/default_fetcher.go:140` を `s.languagesTTL` に変更。
- これに伴い `default_fetcher.go` で未使用になった `time` import を削除。

### ゼロTTLのフォールバック

`internal/cache/memory.go` の `Get` は `time.Since(entry.Timestamp) > entry.TTL` で失効判定する。TTLが0だと経過時間が即座にこれを上回り、エントリが事実上キャッシュされない。これを避けるため、`NewService` で設定値が0以下の場合は安全なデフォルトにフォールバックする:

- transcript: 24時間
- languages: 6時間

## テスト

- `internal/youtube/service_test.go` に `TestCacheTTLConfiguration` を追加。スタブ化した `http.RoundTripper` で YouTube ページとトランスクリプトXMLの応答を差し替え、`GetTranscript` / `ListAvailableLanguages` を実行し、モックキャッシュが記録した `cache.Set` のTTL引数を検証する。
  - `transcript uses configured TTL`: `TranscriptTTL=2h` → `cache.Set` に 2h が渡る。
  - `languages uses configured TTL`: `LanguagesTTL=3h` → `cache.Set` に 3h が渡る。
  - `zero transcript TTL falls back to 24h`: 未設定 → 24h にフォールバック。
  - `zero languages TTL falls back to 6h`: 未設定 → 6h にフォールバック。

### 検証結果(すべてパス)

- `gofmt -l internal cmd`: 出力なし(整形差分なし)
- `go build ./...`: 成功
- `go test ./... -short`: 122 件パス(8パッケージ)
- `go vet ./...`: 問題なし

## 補足

- go バージョン、README には変更を加えていません。
- `MetadataTTL` / `ErrorTTL` は本PRのスコープ外(現状コード中で対応する `cache.Set` 呼び出しがないため)。
