### PR TITLE
test: 統合スモークテスト+CIジョブを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: [ main, develop ]
   workflow_dispatch:
+  schedule:
+    # Daily 06:00 UTC. Drives the non-blocking live-canary job below; the gating
+    # jobs simply re-run on this schedule, which is harmless.
+    - cron: '0 6 * * *'
 
 env:
   GO_VERSION: '1.24.0'
@@ -92,6 +96,63 @@ jobs:
         flags: unittests
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: false
+
+  # Deterministic integration smoke tests (fixture-driven, no live network).
+  # Part of the gating pipeline. The live canary is skipped here because
+  # YT_LIVE_SMOKE is not set.
+  integration:
+    name: Integration (deterministic)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ env.GO_VERSION }}
+
+    - name: Cache Go modules
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+        key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-${{ env.GO_VERSION }}-
+
+    - name: Download dependencies
+      run: go mod download
+
+    - name: Run deterministic integration tests
+      run: go test -v -tags=integration ./...
+
+  # Optional LIVE canary against real YouTube. NON-BLOCKING (continue-on-error)
+  # and only on schedule or manual dispatch. YouTube rate-limits CI IP ranges,
+  # so this must never gate merges.
+  live-canary:
+    name: Live Canary (non-blocking)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    continue-on-error: true
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ env.GO_VERSION }}
+
+    - name: Run live canary
+      env:
+        YT_LIVE_SMOKE: '1'
+      run: go test -v -tags=integration -run TestLiveCanary ./tests/integration/...
 
   # Security scan
   security:

--- a/Makefile
+++ b/Makefile
@@ -100,9 +100,9 @@ test-coverage: ## Run tests with coverage report
 	@echo "$(GREEN)Coverage report generated: coverage.html$(NC)"
 
 .PHONY: test-integration
-test-integration: ## Run integration tests
+test-integration: ## Run deterministic integration tests (live canary skipped unless YT_LIVE_SMOKE=1)
 	@echo "$(GREEN)Running integration tests...$(NC)"
-	go test -v -tags=integration ./tests/integration/...
+	go test -v -tags=integration ./...
 
 .PHONY: test-api
 test-api: ## Test API endpoints (requires running server)

--- a/internal/youtube/integration_test.go
+++ b/internal/youtube/integration_test.go
@@ -1,0 +1,243 @@
+//go:build integration
+
+package youtube
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kyong0612/youtube-mcp/internal/config"
+	"github.com/kyong0612/youtube-mcp/internal/models"
+)
+
+// fixtureVideoID is the 11-character video ID embedded in the watch-page fixture.
+const fixtureVideoID = "TESTVIDEO01"
+
+// fixtureTransport is a test-only http.RoundTripper that serves saved fixtures
+// instead of reaching out to YouTube. Installing it on the Service's http.Client
+// lets these tests drive the real, public fetch -> parse -> format pipeline
+// (GetTranscript / FormatTranscript, including retry and status handling)
+// fully offline and deterministically. No production code is modified; only the
+// (unexported) transport field of the test's own Service is swapped.
+//
+// It routes by request path:
+//   - "/watch"            -> the saved watch-page HTML (ytInitialPlayerResponse)
+//   - any path containing "timedtext" -> the saved caption XML
+type fixtureTransport struct {
+	watchHTML   []byte
+	captionXML  []byte
+	watchHits   int
+	captionHits int
+}
+
+func (ft *fixtureTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp := &http.Response{
+		Proto:      "HTTP/1.1",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		Header:     make(http.Header),
+		Request:    req,
+	}
+
+	switch {
+	case req.URL.Path == "/watch":
+		ft.watchHits++
+		resp.StatusCode = http.StatusOK
+		resp.Header.Set("Content-Type", "text/html; charset=utf-8")
+		resp.Body = io.NopCloser(bytes.NewReader(ft.watchHTML))
+	case strings.Contains(req.URL.Path, "timedtext"):
+		ft.captionHits++
+		resp.StatusCode = http.StatusOK
+		resp.Header.Set("Content-Type", "application/xml; charset=utf-8")
+		resp.Body = io.NopCloser(bytes.NewReader(ft.captionXML))
+	default:
+		resp.StatusCode = http.StatusNotFound
+		resp.Body = io.NopCloser(bytes.NewReader(nil))
+	}
+
+	return resp, nil
+}
+
+// newFixtureService builds a Service whose HTTP transport serves the given
+// caption fixture (and the shared watch-page fixture), with a fresh in-memory
+// mock cache. Rate limits are set generously so the test never blocks.
+func newFixtureService(t *testing.T, captionFixture string) (*Service, *fixtureTransport) {
+	t.Helper()
+
+	cfg := config.YouTubeConfig{
+		DefaultLanguages:   []string{"en"},
+		RequestTimeout:     5 * time.Second,
+		RetryAttempts:      2,
+		RetryDelay:         time.Millisecond,
+		RateLimitPerMinute: 600,
+		RateLimitPerHour:   6000,
+		MaxConcurrent:      4,
+		UserAgent:          "youtube-mcp-integration-test",
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	svc := NewService(cfg, newMockCache(), logger)
+
+	ft := &fixtureTransport{
+		watchHTML:  readFixture(t, "watch_page.html"),
+		captionXML: readFixture(t, captionFixture),
+	}
+	svc.httpClient.Transport = ft
+
+	return svc, ft
+}
+
+func readFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("testdata", name))
+	if err != nil {
+		t.Fatalf("failed to read fixture %q: %v", name, err)
+	}
+	return data
+}
+
+// TestIntegration_FetchParseFormatPipeline exercises the full public path:
+// GetTranscript fetches the watch page over HTTP (intercepted), parses
+// ytInitialPlayerResponse, selects the caption track, fetches the caption XML
+// over HTTP (intercepted), parses it into segments, and produces the default
+// formatted text. It asserts the actual fetch happened and the parsed/formatted
+// output is exactly as expected.
+func TestIntegration_FetchParseFormatPipeline(t *testing.T) {
+	svc, ft := newFixtureService(t, "timedtext_transcript.xml")
+
+	resp, err := svc.GetTranscript(context.Background(), fixtureVideoID, []string{"en"}, false)
+	if err != nil {
+		t.Fatalf("GetTranscript returned error: %v", err)
+	}
+
+	// The fetch path was actually exercised over the (intercepted) HTTP client.
+	if ft.watchHits == 0 {
+		t.Error("expected the watch page to be fetched through the HTTP client")
+	}
+	if ft.captionHits == 0 {
+		t.Error("expected the caption track URL to be fetched through the HTTP client")
+	}
+
+	// Metadata parsed from the watch-page fixture.
+	if resp.VideoID != fixtureVideoID {
+		t.Errorf("VideoID = %q, want %q", resp.VideoID, fixtureVideoID)
+	}
+	if resp.Title != "Integration Test Video" {
+		t.Errorf("Title = %q, want %q", resp.Title, "Integration Test Video")
+	}
+	if resp.Language != "en" {
+		t.Errorf("Language = %q, want %q", resp.Language, "en")
+	}
+	if resp.Metadata.ChannelName != "Test Channel" {
+		t.Errorf("Metadata.ChannelName = %q, want %q", resp.Metadata.ChannelName, "Test Channel")
+	}
+	if resp.Metadata.ViewCount != 12345 {
+		t.Errorf("Metadata.ViewCount = %d, want 12345", resp.Metadata.ViewCount)
+	}
+
+	// Segments parsed from the caption XML fixture.
+	wantTexts := []string{"Hello and welcome", "to the integration test", "of the YouTube MCP server"}
+	if got := len(resp.Transcript); got != len(wantTexts) {
+		t.Fatalf("segment count = %d, want %d", got, len(wantTexts))
+	}
+	for i, want := range wantTexts {
+		if resp.Transcript[i].Text != want {
+			t.Errorf("segment[%d].Text = %q, want %q", i, resp.Transcript[i].Text, want)
+		}
+	}
+	if resp.Transcript[0].Start != 0 || resp.Transcript[0].End != 2.5 {
+		t.Errorf("segment[0] timing = (%.3f, %.3f), want (0, 2.5)", resp.Transcript[0].Start, resp.Transcript[0].End)
+	}
+	if resp.DurationSeconds != 8.0 {
+		t.Errorf("DurationSeconds = %.3f, want 8.0", resp.DurationSeconds)
+	}
+
+	// Default formatted text.
+	wantPlain := "Hello and welcome to the integration test of the YouTube MCP server"
+	if resp.FormattedText != wantPlain {
+		t.Errorf("FormattedText = %q, want %q", resp.FormattedText, wantPlain)
+	}
+}
+
+// TestIntegration_FormatTranscriptOutputs drives FormatTranscript end-to-end for
+// the timestamped output formats and asserts the exact serialized result.
+func TestIntegration_FormatTranscriptOutputs(t *testing.T) {
+	cases := []struct {
+		name       string
+		formatType string
+		want       string
+	}{
+		{
+			name:       "plain_text",
+			formatType: models.FormatTypePlainText,
+			want:       "Hello and welcome to the integration test of the YouTube MCP server",
+		},
+		{
+			name:       "srt",
+			formatType: models.FormatTypeSRT,
+			want: "1\n00:00:00,000 --> 00:00:02,500\nHello and welcome\n\n" +
+				"2\n00:00:02,500 --> 00:00:05,500\nto the integration test\n\n" +
+				"3\n00:00:05,500 --> 00:00:08,000\nof the YouTube MCP server",
+		},
+		{
+			name:       "vtt",
+			formatType: models.FormatTypeVTT,
+			want: "WEBVTT\n\n" +
+				"00:00:00.000 --> 00:00:02.500\nHello and welcome\n\n" +
+				"00:00:02.500 --> 00:00:05.500\nto the integration test\n\n" +
+				"00:00:05.500 --> 00:00:08.000\nof the YouTube MCP server",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc, _ := newFixtureService(t, "timedtext_transcript.xml")
+
+			resp, err := svc.FormatTranscript(context.Background(), fixtureVideoID, tc.formatType, false)
+			if err != nil {
+				t.Fatalf("FormatTranscript(%s) error: %v", tc.formatType, err)
+			}
+			if resp.FormattedText != tc.want {
+				t.Errorf("FormatTranscript(%s) mismatch\n got: %q\nwant: %q", tc.formatType, resp.FormattedText, tc.want)
+			}
+		})
+	}
+}
+
+// TestIntegration_TimedTextFormatPipeline exercises the same public path but with
+// a caption response in YouTube's <timedtext> format, covering the second branch
+// of parseTranscriptXML through the real fetch path.
+func TestIntegration_TimedTextFormatPipeline(t *testing.T) {
+	svc, ft := newFixtureService(t, "timedtext_v3.xml")
+
+	resp, err := svc.GetTranscript(context.Background(), fixtureVideoID, []string{"en"}, false)
+	if err != nil {
+		t.Fatalf("GetTranscript returned error: %v", err)
+	}
+	if ft.captionHits == 0 {
+		t.Error("expected the caption track URL to be fetched through the HTTP client")
+	}
+
+	wantTexts := []string{"Hello and welcome", "to the timedtext format"}
+	if got := len(resp.Transcript); got != len(wantTexts) {
+		t.Fatalf("segment count = %d, want %d", got, len(wantTexts))
+	}
+	for i, want := range wantTexts {
+		if resp.Transcript[i].Text != want {
+			t.Errorf("segment[%d].Text = %q, want %q", i, resp.Transcript[i].Text, want)
+		}
+	}
+
+	wantPlain := "Hello and welcome to the timedtext format"
+	if resp.FormattedText != wantPlain {
+		t.Errorf("FormattedText = %q, want %q", resp.FormattedText, wantPlain)
+	}
+}

--- a/internal/youtube/testdata/timedtext_transcript.xml
+++ b/internal/youtube/testdata/timedtext_transcript.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="utf-8" ?><transcript><text start="0" dur="2.5">Hello and welcome</text><text start="2.5" dur="3">to the integration test</text><text start="5.5" dur="2.5">of the YouTube MCP server</text></transcript>

--- a/internal/youtube/testdata/timedtext_v3.xml
+++ b/internal/youtube/testdata/timedtext_v3.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="utf-8"?><timedtext format="3"><body><p t="0" d="2">Hello and welcome</p><p t="2" d="3">to the timedtext format</p></body></timedtext>

--- a/internal/youtube/testdata/watch_page.html
+++ b/internal/youtube/testdata/watch_page.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head><title>Integration Test Video</title></head>
+<body>
+<!--
+  Minimal, hand-written fixture mimicking a YouTube /watch page.
+  parseVideoData() extracts the single-line player-response assignment in the
+  script tag below via regex, so that line MUST stay on one line.
+  The caption track baseUrl points at the YouTube timedtext endpoint; the test's
+  http.RoundTripper intercepts it and serves a saved caption XML fixture instead.
+-->
+<script>var ytInitialPlayerResponse = {"videoDetails":{"videoId":"TESTVIDEO01","title":"Integration Test Video","shortDescription":"A deterministic fixture used by the integration smoke tests.","channelId":"UCtest000000000000000000","author":"Test Channel","viewCount":"12345","isLiveContent":false},"captions":{"playerCaptionsTracklistRenderer":{"captionTracks":[{"baseUrl":"https://www.youtube.com/api/timedtext?v=TESTVIDEO01&lang=en","name":{"simpleText":"English"},"vssId":".en","languageCode":"en","isTranslatable":true,"isDefault":true}]}}};</script>
+</body>
+</html>

--- a/tests/integration/live_canary_test.go
+++ b/tests/integration/live_canary_test.go
@@ -1,0 +1,60 @@
+//go:build integration
+
+// Package integration_test holds opt-in, network-dependent smoke tests for the
+// YouTube MCP server.
+//
+// The DETERMINISTIC integration tests live in internal/youtube (white-box,
+// fixture-driven) because they need to swap the HTTP transport. This file holds
+// only the LIVE canary, which is skipped unless YT_LIVE_SMOKE is set: YouTube
+// rate-limits/blocks CI IP ranges, so running it in the gating pipeline would
+// make CI flaky.
+package integration_test
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/kyong0612/youtube-mcp/internal/cache"
+	"github.com/kyong0612/youtube-mcp/internal/config"
+	"github.com/kyong0612/youtube-mcp/internal/youtube"
+)
+
+// TestLiveCanary_GetTranscript fetches a stable, well-known public video over the
+// real network and asserts a non-empty transcript. It is OPT-IN: set
+// YT_LIVE_SMOKE=1 to run. It is intentionally NOT part of the gating CI job.
+func TestLiveCanary_GetTranscript(t *testing.T) {
+	if os.Getenv("YT_LIVE_SMOKE") == "" {
+		t.Skip("live canary skipped; set YT_LIVE_SMOKE=1 to hit the real YouTube network")
+	}
+
+	cfg := config.DefaultConfig().YouTube
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	memCache := cache.NewMemoryCache(100, 64, time.Minute)
+	t.Cleanup(func() { _ = memCache.Close() })
+
+	svc := youtube.NewService(cfg, memCache, logger)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// "Me at the zoo" - the first YouTube video; stable and unlikely to disappear.
+	const videoID = "jNQXAC9IVRw"
+
+	resp, err := svc.GetTranscript(ctx, videoID, []string{"en"}, false)
+	if err != nil {
+		t.Fatalf("live GetTranscript(%s) error: %v", videoID, err)
+	}
+	if len(resp.Transcript) == 0 {
+		t.Fatalf("live GetTranscript(%s) returned no transcript segments", videoID)
+	}
+	if resp.FormattedText == "" {
+		t.Errorf("live GetTranscript(%s) returned empty formatted text", videoID)
+	}
+
+	t.Logf("live canary OK: %d segments, %d chars", len(resp.Transcript), resp.CharCount)
+}


### PR DESCRIPTION
## 概要

YouTube のスクレイピング処理（取得 → パース → フォーマット）を検証する統合スモークテストがこれまで存在しなかったため、**決定論的（ネットワーク非依存）な統合テスト**を追加し、CI に組み込みました。あわせて、本物の YouTube にアクセスする**ライブカナリアテスト**を任意・非ブロッキングで追加しています。

既存のユニットテストは 100% モック化されており、その性質（非フレーキー）は維持しています。本 PR では一切変更していません。

## 決定論的統合テスト（CI のゲート対象）

`internal/youtube/integration_test.go`（`//go:build integration`、`package youtube` のホワイトボックス）

- テスト専用の `http.RoundTripper` を `Service` の HTTP クライアントに差し込み、保存済みフィクスチャを返します。これにより**公開 API である `GetTranscript` / `FormatTranscript` の実際の取得パスを丸ごと**（リトライ・ステータス処理・ウォッチページ取得・字幕 URL 取得を含む）オフラインかつ決定論的に駆動します。**本番コードへのテスト用シーム追加は行っていません**（テスト側の `Service` の非公開フィールドを差し替えるのみ）。
- フィクスチャ（`internal/youtube/testdata/`）:
  - `watch_page.html` … 最小限の `var ytInitialPlayerResponse = {...};` を含むウォッチページ。字幕トラックの `baseUrl` は timedtext エンドポイントを指す。
  - `timedtext_transcript.xml` … `<transcript>` 形式の字幕。
  - `timedtext_v3.xml` … `<timedtext>` 形式の字幕。
- カバーする内容:
  - `TestIntegration_FetchParseFormatPipeline`: 取得 → `ytInitialPlayerResponse` のパース → トラック選択 → 字幕 XML 取得 → セグメント化 → デフォルト整形までを一気通貫で検証。HTTP 取得が実際に発生したこと（ヒット数）、メタデータ（タイトル/チャンネル名/再生数）、セグメント本文・タイムスタンプ、総再生時間を厳密に assert。
  - `TestIntegration_FormatTranscriptOutputs`: `plain_text` / `srt` / `vtt` の整形結果を**完全一致**で検証（テーブル駆動）。
  - `TestIntegration_TimedTextFormatPipeline`: `<timedtext>` 形式を実 HTTP 経由で通し、`parseTranscriptXML` のもう一方の分岐をエンドツーエンドでカバー。

## ライブカナリア（任意・デフォルトでスキップ・非ブロッキング）

`tests/integration/live_canary_test.go`（`//go:build integration`、`package integration_test`、公開 API のみ使用）

- `YT_LIVE_SMOKE` 環境変数が未設定なら `t.Skip` します（**デフォルトでは必ずスキップ**）。
- 安定した既知動画（"Me at the zoo" / `jNQXAC9IVRw`）を実ネットワークで取得し、空でないトランスクリプトを assert します。
- YouTube は CI の IP レンジをレート制限・ブロックするため、ゲート対象のジョブでは**絶対に実行しません**（CI をフレーキーにしないため）。

## CI への組み込み（`.github/workflows/ci.yml`）

- `integration` ジョブを追加（ゲート対象）。`go test -v -tags=integration ./...` を実行。`YT_LIVE_SMOKE` を設定しないため、ライブカナリアはスキップされ決定論的に動作します。
- `live-canary` ジョブを追加（**非ブロッキング**）。`continue-on-error: true` かつ `if: schedule || workflow_dispatch` で、毎日 06:00 UTC の cron か手動実行時のみ動作。失敗してもマージをブロックしません。
- これに伴い `schedule`（cron）トリガーを追加しています。スケジュール実行では既存のゲートジョブも再実行されますが無害です。
- `Makefile` の `test-integration` ターゲットを `./tests/integration/...` から `./...` に変更。決定論的テストはホワイトボックスのため `internal/youtube` 配下に置く必要があり、`make test-integration` と `go test -tags=integration ./...` の双方で実行されるようにするためです。

## カバレッジの正直な限界

- 決定論的テストは**保存済みフィクスチャ**を使うため、「YouTube が現在返す実際の HTML / XML 形式」の妥当性は保証しません。YouTube 側のレスポンス形式変更による回帰は、決定論的テストでは検知できず、（スキップされている）ライブカナリアでのみ検知可能です。
- ウォッチページの URL は本番コードで `https://www.youtube.com/watch?v=ID` にハードコードされています。本テストは**シームを追加せず**、テスト側の `http.RoundTripper` で当該リクエストを横取りして駆動しています。純粋なブラックボックス（httptest へのリダイレクト）はこのハードコードのため不可能でした。
- `<timedtext>` 形式の `t` / `d` 属性は、本番コードがミリ秒→秒の変換を行わず生の `float64` として扱う既知の挙動（`CLAUDE.md` の "Timestamp Issues" 参照）があります。フィクスチャはタイムスタンプが大きくならないよう小さい値にしてあり、テストは**現状の挙動**を固定しています（仕様の正しさを主張するものではありません）。
- ライブカナリアは**デフォルトで実行されない**ため、本 PR の CI 実行では実ネットワーク経路は検証されていません（意図的）。

## ローカル検証結果（すべて pass）

- `go test ./... -short` … pass（ユニットテストへの影響なし）
- `go test -tags=integration ./...` … 123 passed / 9 packages。決定論的統合テストは pass、ライブカナリアは Skip（`YT_LIVE_SMOKE` 未設定）。
- `gofmt -l .` … 出力なし（整形済み）
- `go vet ./...` および `go vet -tags=integration ./...` … 問題なし
- `ci.yml` … `yq` で YAML パース OK
