### PR TITLE
fix(release): stdio版バイナリの生成とリリースowner不整合の修正

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -70,7 +70,7 @@ archives:
       {{- if .Arm }}v{{ .Arm }}{{ end }}
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
     files:
       - README.md
       - LICENSE*
@@ -82,7 +82,7 @@ checksum:
   algorithm: sha256
 
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 
 changelog:
   sort: asc

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,6 +17,7 @@ before:
     - go test -v ./...
 
 builds:
+  # HTTP server binary (used by Docker image / standalone HTTP mode)
   - id: youtube-mcp
     main: ./cmd/server
     binary: youtube-mcp
@@ -36,7 +37,29 @@ builds:
       - -X main.GitCommit={{.ShortCommit}}
     mod_timestamp: '{{ .CommitTimestamp }}'
 
+  # STDIO binary consumed by MCP clients (Claude Desktop / Cursor / Claude Code)
+  - id: youtube-mcp-stdio
+    main: ./cmd/mcp
+    binary: youtube-mcp-stdio
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X main.Version={{.Version}}
+      - -X main.BuildTime={{.Date}}
+      - -X main.GitCommit={{.ShortCommit}}
+    mod_timestamp: '{{ .CommitTimestamp }}'
+
 archives:
+  # No `ids`/`builds` filter is set, so GoReleaser packages ALL builds by default,
+  # i.e. each archive contains both `youtube-mcp` (HTTP) and `youtube-mcp-stdio` (MCP stdio).
   - id: youtube-mcp
     name_template: >-
       {{ .ProjectName }}_
@@ -135,44 +158,62 @@ nfpms:
         file_info:
           mode: 0644
 
-brews:
-  - name: youtube-mcp
-    repository:
-      owner: kimkiyong
-      name: homebrew-tap
-      branch: main
-      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
-    commit_author:
-      name: goreleaserbot
-      email: bot@goreleaser.com
-    commit_msg_template: "Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
-    homepage: "https://github.com/kimkiyong/youtube-mcp"
-    description: "YouTube Transcript MCP Server"
-    license: "MIT"
-    skip_upload: auto
-    test: |
-      system "#{bin}/youtube-mcp", "--version"
-    install: |
-      bin.install "youtube-mcp"
-
-scoops:
-  - repository:
-      owner: kimkiyong
-      name: scoop-bucket
-      branch: main
-      token: "{{ .Env.SCOOP_BUCKET_GITHUB_TOKEN }}"
-    commit_author:
-      name: goreleaserbot
-      email: bot@goreleaser.com
-    commit_msg_template: "Scoop update for {{ .ProjectName }} version {{ .Tag }}"
-    homepage: "https://github.com/kimkiyong/youtube-mcp"
-    description: "YouTube Transcript MCP Server"
-    license: "MIT"
-    skip_upload: auto
+# NOTE: brews/scoops are DISABLED for now.
+# They publish to EXTERNAL tap repositories owned by a different account
+# (kimkiyong/homebrew-tap, kimkiyong/scoop-bucket) and require Personal Access
+# Token secrets (HOMEBREW_TAP_GITHUB_TOKEN / SCOOP_BUCKET_GITHUB_TOKEN) that do
+# not currently exist. If left enabled, a missing token / missing tap repo makes
+# the whole `goreleaser release` run hard-fail. They are commented out so core
+# release artifacts (binaries, archives, checksums, GHCR image) can ship.
+#
+# To re-enable:
+#   1. Create the tap repositories (e.g. kyong0612/homebrew-tap and
+#      kyong0612/scoop-bucket) and update the `owner` fields below accordingly.
+#   2. Create a GitHub PAT with `repo` scope on those repositories and register
+#      it as Actions secrets HOMEBREW_TAP_GITHUB_TOKEN and SCOOP_BUCKET_GITHUB_TOKEN.
+#   3. Expose those secrets to the GoReleaser step (env:) in .github/workflows/release.yml.
+#   4. Uncomment the blocks below.
+#
+# brews:
+#   - name: youtube-mcp
+#     repository:
+#       owner: kimkiyong
+#       name: homebrew-tap
+#       branch: main
+#       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+#     commit_author:
+#       name: goreleaserbot
+#       email: bot@goreleaser.com
+#     commit_msg_template: "Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
+#     homepage: "https://github.com/kyong0612/youtube-mcp"
+#     description: "YouTube Transcript MCP Server"
+#     license: "MIT"
+#     skip_upload: auto
+#     test: |
+#       system "#{bin}/youtube-mcp", "--version"
+#     install: |
+#       bin.install "youtube-mcp"
+#
+# scoops:
+#   - repository:
+#       owner: kimkiyong
+#       name: scoop-bucket
+#       branch: main
+#       token: "{{ .Env.SCOOP_BUCKET_GITHUB_TOKEN }}"
+#     commit_author:
+#       name: goreleaserbot
+#       email: bot@goreleaser.com
+#     commit_msg_template: "Scoop update for {{ .ProjectName }} version {{ .Tag }}"
+#     homepage: "https://github.com/kyong0612/youtube-mcp"
+#     description: "YouTube Transcript MCP Server"
+#     license: "MIT"
+#     skip_upload: auto
 
 release:
   github:
-    owner: kimkiyong
+    # The actual upstream repository is kyong0612/youtube-mcp.
+    # The GitHub Release MUST be published there.
+    owner: kyong0612
     name: youtube-mcp
   draft: false
   prerelease: auto


### PR DESCRIPTION
## なぜ必要か (Why)

MCPクライアント（Claude Desktop / Cursor / Claude Code）は、標準入出力（STDIO）で通信するバイナリを必要とする。これはリポジトリの `./cmd/mcp`（バイナリ名 `youtube-mcp-stdio`）からビルドされる。

しかし現状の `.goreleaser.yml` は `./cmd/server`（HTTPサーバ、バイナリ名 `youtube-mcp`）しかビルドしていないため、リリース成果物に **MCPクライアントが実際に使うSTDIOバイナリが含まれていなかった**。これではリリースを作っても利用者がMCPサーバとして使えない。

加えて、リリース先のownerが実体と異なる `kimkiyong` にハードコードされており、このまま走らせるとGitHub Releaseが誤ったアカウント宛になる（または失敗する）問題があった。

## 変更内容 (What)

### 1. STDIOバイナリのビルド追加
- `builds:` に2つ目のエントリ `youtube-mcp-stdio`（`main: ./cmd/mcp`）を追加。
- 既存の `youtube-mcp`（`./cmd/server`）ビルドはそのまま維持。
- 新エントリは既存と同じ設定（`CGO_ENABLED=0`、`linux/windows/darwin` × `amd64/arm64`、`-X main.Version` / `main.BuildTime` / `main.GitCommit` を注入するldflags）。両 `main` パッケージとも同名のバージョン変数を公開しているため、同一ldflagsで問題なく注入できることを確認済み。
- `archives:` は `ids`/`builds` フィルタを指定していないため、デフォルトで全ビルドを同梱する。つまり各アーカイブに `youtube-mcp`（HTTP）と `youtube-mcp-stdio`（STDIO）の **両方** が含まれる。その旨をコメントで明記。

### 2. リリースowner不整合の修正
- `release.github.owner` を `kimkiyong` → `kyong0612` に修正。GitHub Releaseが正しく `kyong0612/youtube-mcp` に発行されるようにした。

### 3. brews / scoops の一時無効化
- `brews` / `scoops` は **外部の** tapリポジトリ（`kimkiyong/homebrew-tap`、`kimkiyong/scoop-bucket`、別アカウントの可能性あり）へpushする設定で、`HOMEBREW_TAP_GITHUB_TOKEN` / `SCOOP_BUCKET_GITHUB_TOKEN` というPATシークレットを必要とする。これらが存在しないと **リリース全体がhard-failする**。
- そのため両ブロックをコメントアウトし、再有効化手順（tapリポジトリ作成 → PAT発行 → Actionsシークレット登録 → ブロックのコメント解除）をYAML内のNOTEとして明記した。シークレットを勝手に発明することはしていない。
- Docker / GHCR の設定は指示どおり変更していない。

## このPRの位置づけ

このPRは設定ファイル（`.goreleaser.yml`）の修正のみ。リリースワークフロー（GoReleaserジョブ）の再有効化を行う #23 と **対になって初めてリリースが正しく機能する**。本PR単体ではリリースは走らない（ワークフローは現状プレースホルダーのまま）。

## 前提条件 (Prerequisites)

- GitHub Release本体: 追加シークレット不要（`GITHUB_TOKEN` で `kyong0612/youtube-mcp` に発行）。
- Docker/GHCR: 既存設定のまま（`GITHUB_REPOSITORY_OWNER` を利用）。
- Homebrew/Scoop配布を使いたい場合のみ: 上記NOTEのとおりtapリポジトリとPATシークレットの準備が別途必要。

## 検証 (Verification)

- `go build ./cmd/mcp ./cmd/server`: 成功
- `go build ./...`: 成功
- YAMLパース（`ruby -ryaml`）: 成功
- `goreleaser check`（v2.16.0）: **設定は valid**。非ゼロ終了は既存の deprecation 警告（`snapshot.name_template` / `archives.format_overrides.format` / `dockers`）によるもので、本PRの変更が原因ではない（いずれも今回のスコープ外）。
