### PR TITLE
fix(docker): Dockerバージョン注入の修正とGoReleaser用Dockerfile追加

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -116,12 +116,17 @@ dockers:
   - id: youtube-mcp
     goos: linux
     goarch: amd64
+    # Only copy the HTTP server binary (build id youtube-mcp) into the docker
+    # build context, so Dockerfile.goreleaser can `COPY youtube-mcp` directly.
+    ids:
+      - youtube-mcp
     image_templates:
       - "ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/youtube-transcript-mcp:latest"
       - "ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/youtube-transcript-mcp:{{ .Tag }}"
       - "ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/youtube-transcript-mcp:{{ .Major }}"
       - "ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/youtube-transcript-mcp:{{ .Major }}.{{ .Minor }}"
-    dockerfile: Dockerfile
+    # GoReleaser-specific Dockerfile: copies the prebuilt binary (no build-from-source).
+    dockerfile: Dockerfile.goreleaser
     build_flag_templates:
       - "--pull"
       - "--label=org.opencontainers.image.created={{.Date}}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.23-alpine AS builder
+FROM golang:1.24-alpine AS builder
 
 # Install git and ca-certificates for HTTPS requests
 RUN apk add --no-cache git ca-certificates tzdata
@@ -22,11 +22,18 @@ RUN go mod verify
 # Copy source code
 COPY . .
 
+# Build-time metadata, injected into the binary via -ldflags.
+# Passed from `docker build --build-arg ...` (see Makefile `docker-build` and
+# docker-compose.yml `build.args`). Defaults keep ad-hoc `docker build .` working.
+ARG VERSION=dev
+ARG GIT_COMMIT=unknown
+ARG BUILD_TIME=unknown
+
 # Build the application
 # CGO_ENABLED=0 for static binary
 # -ldflags for smaller binary and version injection
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
-    -ldflags="-w -s -X main.Version=1.0.0 -X main.BuildTime=$(date -u '+%Y-%m-%d_%H:%M:%S') -X main.GitCommit=$(git rev-parse --short HEAD 2>/dev/null || echo 'unknown')" \
+    -ldflags="-w -s -X main.Version=${VERSION} -X main.GitCommit=${GIT_COMMIT} -X main.BuildTime=${BUILD_TIME}" \
     -a -installsuffix cgo \
     -o youtube-transcript-mcp \
     ./cmd/server/main.go

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,0 +1,42 @@
+# Dockerfile used by GoReleaser's `dockers` block (see .goreleaser.yml).
+#
+# IMPORTANT: GoReleaser does NOT build from source here. Its docker build context
+# contains ONLY the binaries already produced by the `builds` section (plus any
+# declared extra_files). Therefore this Dockerfile must NOT run `go build` / `COPY . .`
+# (that is what the root `Dockerfile` does). It simply copies the prebuilt
+# `youtube-mcp` HTTP server binary (build id: youtube-mcp) into a minimal image.
+FROM alpine:latest
+
+# ca-certificates for HTTPS, tzdata for timezones, curl for the healthcheck.
+RUN apk --no-cache add ca-certificates tzdata curl
+
+ENV TZ=UTC
+
+# Create non-root user and app directory.
+RUN addgroup -g 1000 appuser && \
+    adduser -D -H -u 1000 -G appuser appuser && \
+    mkdir -p /app && chown appuser:appuser /app
+
+WORKDIR /app
+
+# Copy the prebuilt HTTP server binary from the GoReleaser build context.
+# The name must match the `binary:` of the goreleaser build id `youtube-mcp`.
+COPY youtube-mcp /app/youtube-mcp
+
+USER appuser
+
+# Expose HTTP and metrics ports.
+EXPOSE 8080 9090
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+    CMD curl -f http://localhost:8080/health || exit 1
+
+# Set default environment variables
+ENV PORT=8080 \
+    LOG_LEVEL=info \
+    LOG_FORMAT=json \
+    CACHE_ENABLED=true \
+    CACHE_TYPE=memory
+
+ENTRYPOINT ["/app/youtube-mcp"]

--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,10 @@ mod-graph: ## Show dependency graph
 .PHONY: docker-build
 docker-build: ## Build Docker image
 	@echo "$(GREEN)Building Docker image...$(NC)"
-	docker build -t $(DOCKER_IMAGE) --build-arg VERSION=$(VERSION) .
+	docker build -t $(DOCKER_IMAGE) \
+		--build-arg VERSION=$(VERSION) \
+		--build-arg GIT_COMMIT=$(GIT_COMMIT) \
+		--build-arg BUILD_TIME=$(BUILD_TIME) .
 	@echo "$(GREEN)Docker build complete!$(NC)"
 
 .PHONY: docker-run

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       dockerfile: Dockerfile
       args:
         - VERSION=${VERSION:-1.0.0}
+        - GIT_COMMIT=${GIT_COMMIT:-unknown}
+        - BUILD_TIME=${BUILD_TIME:-unknown}
     image: youtube-transcript-mcp:${VERSION:-latest}
     container_name: youtube-transcript-mcp
     restart: unless-stopped


### PR DESCRIPTION
## 概要

レビューで判明した Docker 周りの 4 つの問題を修正します。あわせて、`goreleaser release` の docker ステージが確実に通るよう GoReleaser 専用の Dockerfile を追加します。

> **このPRは #31 (`fix/goreleaser-artifacts`) にスタックしています。** base ブランチは `main` ではなく `fix/goreleaser-artifacts` です。差分は #31 の `.goreleaser.yml` に対する増分になります。

## 修正した4つの問題と対応

### 1. ルート `Dockerfile` がバージョンをハードコードしていた
- **問題**: HTTP サーバ (`./cmd/server`) をビルドする際、`-X main.Version=1.0.0` がハードコードされており、実際のリリースバージョンが反映されなかった (旧 `Dockerfile:29` 付近)。
- **対応**: `ARG VERSION=dev` / `ARG GIT_COMMIT=unknown` / `ARG BUILD_TIME=unknown` を追加し、`-ldflags "-X main.Version=$VERSION -X main.GitCommit=$GIT_COMMIT -X main.BuildTime=$BUILD_TIME"` でビルド引数から注入するようにしました。シンボル名は `cmd/server/main.go` の `package main` の `Version` / `GitCommit` / `BuildTime` と一致することを確認済みです。マルチステージ構成は維持しています。

### 2. `docker-compose.yml` の `--build-arg VERSION` が無視されていた
- **問題**: `docker-compose.yml` は `build.args` で `VERSION` を渡していたが、Dockerfile 側に `ARG VERSION` の宣言が無かったため、ビルド時に無視されていた。
- **対応**: 上記 1 で `ARG` を宣言したことで `VERSION` が有効になります。あわせて `build.args` に `GIT_COMMIT` / `BUILD_TIME` を追加し、新しい `ARG` 名と揃えました。

### 3. `.goreleaser.yml` の `dockers` がソースからビルドするルート Dockerfile を参照していた
- **問題**: `dockers` ブロックがルート `Dockerfile` (内部で `COPY . .` + `go build` する＝ソースからビルドする) を指していた。GoReleaser の docker ビルドコンテキストには**ビルド済みバイナリしか含まれない**ため、実際の `goreleaser release` は docker ステージで必ず失敗していた。
- **対応**: ソースからビルドしない GoReleaser 専用の `Dockerfile.goreleaser` を新規追加。ビルド済みの `youtube-mcp` バイナリを最小ベース (alpine) に `COPY` し、`ENTRYPOINT` を設定するだけの構成です。`.goreleaser.yml` の `dockers.dockerfile` を `Dockerfile.goreleaser` に変更し、`ids: [youtube-mcp]` を追加して HTTP サーバのバイナリ (`youtube-mcp`) だけをコンテキストに入れるようにしました。`COPY` するバイナリ名は GoReleaser のビルド (`binary: youtube-mcp`) と一致しています。既存の image/tag テンプレートはそのまま維持しています。これにより **goreleaser の docker ステージのブロッカーが解消されます**。

### 4. (コンテキスト) クライアントは stdio バイナリを使う
- クライアント (Claude Desktop / Cursor / Claude Code) は stdio の `youtube-mcp-stdio` (`./cmd/mcp`) を使います。HTTP イメージは docker-compose 用です。今回の HTTP イメージ修正はこの棲み分けを崩しません。

## 付随する追加修正 (検証中に発覚した既存バグ)

- **`make docker-build` がそもそも失敗していた**: ルート `Dockerfile` のベースイメージが `golang:1.23-alpine` で固定されていたが、`go.mod` が `go 1.24` と `tool` ディレクティブ (Go 1.24 の機能) を要求するため、`go mod download` が `unknown directive: tool` で失敗していました。これは初期コミット (#1) から存在する**本PRの変更とは無関係な既存バグ**ですが、要件 D (「`make docker-build` を壊さない」) を満たし、かつ上記 1 のバージョン注入を docker build で検証可能にするために、最小限の修正として `golang:1.23-alpine` → `golang:1.24-alpine` にバンプしました。
- `Makefile` の `docker-build` ターゲットに `--build-arg GIT_COMMIT` / `--build-arg BUILD_TIME` を追加しました (既に Makefile 内で計算済みの変数を渡すだけ)。これにより、ARG 化に伴って git commit / build time が `unknown` に退化する回帰を防ぎます。

## 検証結果

実行して **PASS** を確認したもの:
- `go build ./cmd/server ./cmd/mcp ./...` → 成功 (exit 0)。
- `.goreleaser.yml` / `docker-compose.yml` の YAML パース (`yq`) → 両方 OK。
- `go run github.com/goreleaser/goreleaser/v2@latest check` → **exit 0** を維持。
  - 注: `dockers`/`docker_manifests` が将来 `dockers_v2` に置き換えられるという **deprecation 警告**が出ますが、これは本PR以前から存在する警告で、`check` のexit codeは 0 のままです。
- **`docker build` を実際に実行して検証しました** (OrbStack 上の Docker daemon を使用):
  - ルート `Dockerfile`: `--build-arg VERSION=test-1.2.3 --build-arg GIT_COMMIT=deadbeef --build-arg BUILD_TIME=2026-06-30` でビルド成功。生成バイナリに注入値が埋め込まれていることを `strings` で確認 (`-X main.Version=test-1.2.3 -X main.GitCommit=deadbeef -X main.BuildTime=2026-06-30`)。
  - `Dockerfile.goreleaser`: ビルド済み `youtube-mcp` バイナリを用意して `docker build -f Dockerfile.goreleaser` でビルド成功。コンテナを起動して `/version` エンドポイントが注入値 (`version: grl-test`, `git_commit: cafef00d`, `build_time: 2026-06-30`) を返すことを確認。

検証できなかった / 限定的なもの (正直に明記):
- `Dockerfile.goreleaser` のローカル検証は OrbStack daemon に合わせて **linux/arm64** でビルドしました。GoReleaser の本番設定は **linux/amd64** (`--platform=linux/amd64`) です。構造とフロー (バイナリの COPY → 起動) は同一なので問題ないと考えますが、amd64 での実ビルドは未実施です。
- 実際の `goreleaser release` (タグを打って GHCR に push する完全なリリース) は未実行です。検証は `goreleaser check` と個別の `docker build` までです。
